### PR TITLE
Include error message from stderr in server response

### DIFF
--- a/http-server/swagger_server/controllers/controller.py
+++ b/http-server/swagger_server/controllers/controller.py
@@ -192,6 +192,7 @@ def runcommand(command, body: AdapterConfig, environment=None, good_response_cod
 
             message = "No result from adapter"
             if len(err):
+                err = err.strip("\n")
                 message += f". Captured stderr:\n  {err}"
 
             return message, 500

--- a/vrealize_operations_integration_sdk/serialization.py
+++ b/vrealize_operations_integration_sdk/serialization.py
@@ -48,7 +48,9 @@ class ResponseBundle:
         if not self.response.is_success:
             message = f"{self.response.status_code} {self.response.reason_phrase}"
             if hasattr(self.response, "text"):
-                message += "\n" + self.response.text.encode('latin1', 'backslashreplace').decode('unicode-escape')
+                encoded = self.response.text.encode('latin1', 'backslashreplace').strip(b'"')
+                message += "\n" + encoded.decode('unicode-escape')
+
         elif "errorMessage" in self.response.text:
             message = json.loads(self.response.text).get('errorMessage')
 


### PR DESCRIPTION
Jira Ticket: [VOPERATION-34120](https://jira.eng.vmware.com/browse/VOPERATION-34120)

Example output:
```
Building adapter image
Starting adapter HTTP server
Waiting for HTTP server to start...
Waiting for HTTP server to start...
HTTP Server started with api version 1.0.0
Collection Failed: 500 INTERNAL SERVER ERROR
"No result from adapter. Captured stderr:
  Traceback (most recent call last):
  File "/home/vrops-adapter-user/src/app/app/adapter.py", line 196, in <module>
    main(sys.argv[1:])
  File "/home/vrops-adapter-user/src/app/app/adapter.py", line 189, in main
    collect(adapter_instance).send_results()
  File "/home/vrops-adapter-user/src/app/app/adapter.py", line 81, in collect
    raise Exception("Oh no there is an unhandled exception!")
Exception: Oh no there is an unhandled exception!
"


Unknown response http status: 500
Unable to cross check collection against describe.xml: 500 INTERNAL SERVER ERROR
Unable to validate relationship: 500 INTERNAL SERVER ERROR
All validation logs written to '/Users/squirogacubi/code/tvg_vrops/Container/open-sdk-project/long-run-mp/logs/validation.log'
```