### PR TITLE
Describe xml validation message

### DIFF
--- a/vrealize_operations_integration_sdk/mp_test.py
+++ b/vrealize_operations_integration_sdk/mp_test.py
@@ -24,6 +24,7 @@ from flask import json
 from httpx import ReadTimeout, Response
 from prompt_toolkit.validation import ConditionalValidator
 from requests import RequestException, Request
+from xmlschema import XMLSchemaValidationError
 
 from vrealize_operations_integration_sdk.constant import DEFAULT_PORT, API_VERSION_ENDPOINT, ENDPOINTS_URLS_ENDPOINT, \
     CONNECT_ENDPOINT, COLLECT_ENDPOINT, DEFAULT_MEMORY_LIMIT
@@ -526,6 +527,10 @@ def main():
         logger.error(f"Unable to parse describe.xml: {describe_error}")
     except SystemExit as system_exit:
         exit(system_exit.code)
+    except XMLSchemaValidationError as xml_error:
+        logger.error(xml_error)
+        logger.error("Fix describe.xml before proceeding")
+        exit(1)
     except BaseException as base_error:
         print_formatted("Unexpected error")
         logger.error(base_error)


### PR DESCRIPTION
Add error handling around describe.xml validation to prevent users from seeing python stack trace. 
 Jira ticker: https://jira.eng.vmware.com/browse/VOPERATION-34208
 
## Old output:
 ```
Unexpected error
failed validating 'string' with XsdAtomicBuiltin(name='xs:integer'):

Reason: attribute dispOrder='string': invalid literal for int() with base 10: 'string'

Schema:

  <xs:simpleType xmlns:xs="http://www.w3.org/2001/XMLSchema" name="integer" id="integer">
    <xs:annotation>
      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#integer" />
    </xs:annotation>
    <xs:restriction base="xs:decimal">
      <xs:fractionDigits value="0" fixed="true" id="integer.fractionDigits" />
      <xs:pattern value="[\-+]?[0-9]+" />
    </xs:restriction>
  </xs:simpleType>

Instance:

  <ResourceIdentifier xmlns="http://schemas.vmware.com/vcops/schema" dispOrder="string" key="ID" length="" nameKey="3" required="true" type="string" identType="1" enum="false" default="" />

Path: /AdapterKind/ResourceKinds/ResourceKind[1]/ResourceIdentifier[1]

  File "/Users/squirogacubi/code/tvg_vrops/Container/open-sdk-project/vrops-integration-sdk/vrealize_operations_integration_sdk/mp_test.py", line 510, in main
    asyncio.run(run(parser.parse_args()))
  File "/usr/local/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/Users/squirogacubi/code/tvg_vrops/Container/open-sdk-project/vrops-integration-sdk/vrealize_operations_integration_sdk/mp_test.py", line 169, in run
    connection = get_connection(project, arguments)
  File "/Users/squirogacubi/code/tvg_vrops/Container/open-sdk-project/vrops-integration-sdk/vrealize_operations_integration_sdk/mp_test.py", line 328, in get_connection
    validate_describe(project.path)
  File "/Users/squirogacubi/code/tvg_vrops/Container/open-sdk-project/vrops-integration-sdk/vrealize_operations_integration_sdk/validation/describe_checks.py", line 234, in validate_describe
    schema.validate(os.path.join(path, "conf", "describe.xml"))
  File "/Users/squirogacubi/code/tvg_vrops/Container/open-sdk-project/vrops-integration-sdk/venv/lib/python3.9/site-packages/xmlschema/validators/schemas.py", line 1694, in validate
    raise error
 ```

## New output: 
```
failed validating 'string' with XsdAtomicBuiltin(name='xs:integer'):

Reason: attribute dispOrder='string': invalid literal for int() with base 10: 'string'

Schema:

  <xs:simpleType xmlns:xs="http://www.w3.org/2001/XMLSchema" name="integer" id="integer">
    <xs:annotation>
      <xs:documentation source="http://www.w3.org/TR/xmlschema-2/#integer" />
    </xs:annotation>
    <xs:restriction base="xs:decimal">
      <xs:fractionDigits value="0" fixed="true" id="integer.fractionDigits" />
      <xs:pattern value="[\-+]?[0-9]+" />
    </xs:restriction>
  </xs:simpleType>

Instance:

  <ResourceIdentifier xmlns="http://schemas.vmware.com/vcops/schema" dispOrder="string" key="ID" length="" nameKey="3" required="true" type="string" identType="1" enum="false" default="" />

Path: /AdapterKind/ResourceKinds/ResourceKind[1]/ResourceIdentifier[1]

Fix describe.xml before proceeding
```