### PR TITLE
Fix stringified nulls

### DIFF
--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vmware-aria-operations-integration-sdk-lib
-version = 0.4.2
+version = 0.4.3
 author = VMware, Inc.
 author_email = krokos@vmware.com
 description = Object model for interacting with the VMware Aria Operations Containerized API

--- a/lib/python/src/aria/ops/definition/adapter_definition.py
+++ b/lib/python/src/aria/ops/definition/adapter_definition.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from collections import OrderedDict
+from typing import Optional
 
 from aria.ops.definition.assertions import validate_key
 from aria.ops.definition.credential_type import CredentialType
@@ -17,9 +18,9 @@ from aria.ops.pipe_utils import write_to_pipe
 class AdapterDefinition(GroupType):
     def __init__(self,
                  key: str,
-                 label: str = None,
-                 adapter_instance_key: str = None,
-                 adapter_instance_label: str = None,
+                 label: Optional[str] = None,
+                 adapter_instance_key: Optional[str] = None,
+                 adapter_instance_label: Optional[str] = None,
                  version: int = 1):
         """
         :param key: The adapter key is used to identify the adapter and its object types. It must be unique across
@@ -82,8 +83,13 @@ class AdapterDefinition(GroupType):
         # The server always invokes methods with the output file as the last argument
         write_to_pipe(output_pipe, self.to_json())
 
-    def define_string_parameter(self, key: str, label: str = None, description: str = None, default: str = None,
-                                max_length: int = 512, required: bool = True, advanced: bool = False):
+    def define_string_parameter(self, key: str,
+                                label: Optional[str] = None,
+                                description: Optional[str] = None,
+                                default: Optional[str] = None,
+                                max_length: int = 512,
+                                required: bool = True,
+                                advanced: bool = False):
         """
         Create a new string parameter and add it to the adapter instance. The user will be asked to provide a value for
         this parameter each time a new account/adapter instance is created.
@@ -101,8 +107,12 @@ class AdapterDefinition(GroupType):
         self.add_parameter(parameter)
         return parameter
 
-    def define_int_parameter(self, key: str, label: str = None, description: str = None,
-                             default: int = None, required: bool = True, advanced: bool = False):
+    def define_int_parameter(self, key: str,
+                             label: Optional[str] = None,
+                             description: Optional[str] = None,
+                             default: Optional[int] = None,
+                             required: bool = True,
+                             advanced: bool = False):
         """
         Create a new integer parameter and add it to the adapter instance. The user will be asked to provide a value for
         this parameter each time a new account/adapter instance is created.
@@ -119,8 +129,13 @@ class AdapterDefinition(GroupType):
         self.add_parameter(parameter)
         return parameter
 
-    def define_enum_parameter(self, key: str, values: list[str], label: str = None, description: str = None,
-                              default: str = None, required: bool = True, advanced: bool = False):
+    def define_enum_parameter(self, key: str,
+                              values: list[str],
+                              label: Optional[str] = None,
+                              description: Optional[str] = None,
+                              default: Optional[str] = None,
+                              required: bool = True,
+                              advanced: bool = False):
         """
         Create a new enum parameter and add it to the adapter instance. The user will be asked to provide a value for
         this parameter each time a new account/adapter instance is created.
@@ -151,7 +166,7 @@ class AdapterDefinition(GroupType):
             raise DuplicateKeyException(f"Parameter with key {key} already exists in adapter definition.")
         self.parameters[key] = parameter
 
-    def define_credential_type(self, key: str = "default_credential", label: str = None):
+    def define_credential_type(self, key: str = "default_credential", label: Optional[str] = None):
         """
         Create a new credential type and add it to this adapter instance. When more than one credential types are
         present, The user will be required to select the type and then fill in the parameters for that type, as only
@@ -186,7 +201,7 @@ class AdapterDefinition(GroupType):
             raise DuplicateKeyException(f"Credential type with key {key} already exists in adapter definition.")
         self.credentials[key] = credential_type
 
-    def define_object_type(self, key: str, label: str = None):
+    def define_object_type(self, key: str, label: Optional[str] = None):
         """
         Create a new object type definition and add it to this adapter definition.
         :param key: The object type

--- a/lib/python/src/aria/ops/definition/attribute.py
+++ b/lib/python/src/aria/ops/definition/attribute.py
@@ -17,7 +17,7 @@ class Attribute(ABC):
                  is_kpi: bool = False,
                  is_impact: bool = False,
                  is_key_attribute: bool = False,
-                 dashboard_order: int = None):
+                 dashboard_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param label: Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
@@ -69,7 +69,7 @@ class MetricAttribute(Attribute):
                  is_kpi: bool = False,
                  is_impact: bool = False,
                  is_key_attribute: bool = False,
-                 dashboard_order: int = None):
+                 dashboard_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param label: Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
@@ -105,7 +105,7 @@ class PropertyAttribute(Attribute):
                  is_kpi: bool = False,
                  is_impact: bool = False,
                  is_key_attribute: bool = False,
-                 dashboard_order: int = None):
+                 dashboard_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param label: Label that is displayed in the VMware Aria Operations UI. Defaults to the key.

--- a/lib/python/src/aria/ops/definition/attribute.py
+++ b/lib/python/src/aria/ops/definition/attribute.py
@@ -1,6 +1,7 @@
 #  Copyright 2022 VMware, Inc.
 #  SPDX-License-Identifier: Apache-2.0
 from abc import ABC
+from typing import Optional
 
 from aria.ops.definition.assertions import validate_key
 from aria.ops.definition.units import Unit
@@ -9,8 +10,8 @@ from aria.ops.definition.units import Unit
 class Attribute(ABC):
     def __init__(self,
                  key: str,
-                 label: str = None,
-                 unit: Unit = None,
+                 label: Optional[str] = None,
+                 unit: Optional[Unit] = None,
                  is_rate: bool = False,
                  is_discrete: bool = False,
                  is_kpi: bool = False,
@@ -65,8 +66,8 @@ class Attribute(ABC):
 
 class MetricAttribute(Attribute):
     def __init__(self, key: str,
-                 label: str = None,
-                 unit: Unit = None,
+                 label: Optional[str] = None,
+                 unit: Optional[Unit] = None,
                  is_rate: bool = False,
                  is_discrete: bool = False,
                  is_kpi: bool = False,
@@ -103,9 +104,9 @@ class MetricAttribute(Attribute):
 
 class PropertyAttribute(Attribute):
     def __init__(self, key: str,
-                 label: str = None,
+                 label: Optional[str] = None,
                  is_string: bool = True,
-                 unit: Unit = None,
+                 unit: Optional[Unit] = None,
                  is_rate: bool = False,
                  is_discrete: bool = False,
                  is_kpi: bool = False,

--- a/lib/python/src/aria/ops/definition/attribute.py
+++ b/lib/python/src/aria/ops/definition/attribute.py
@@ -16,7 +16,6 @@ class Attribute(ABC):
                  is_discrete: bool = False,
                  is_kpi: bool = False,
                  is_impact: bool = False,
-                 dt_type: str = None,
                  is_key_attribute: bool = False,
                  dashboard_order: int = None):
         """
@@ -32,7 +31,6 @@ class Attribute(ABC):
         'Self - Health Score' metric, which can affect the 'Anomalies' Badge.
         :param is_impact: If set, this attribute will never be the 'root cause' of an issue. For example, it could be a
         proxy to a root cause, but not the root cause itself.
-        :param dt_type: The type of algorithm to use for dynamic thresholding.
         :param is_key_attribute: True if the attribute should be shown in some object summary widgets in the UI.
         :param dashboard_order: Determines the order parameters will be displayed in the UI.
         """
@@ -45,7 +43,6 @@ class Attribute(ABC):
         self.is_discrete = is_discrete
         self.is_kpi = is_kpi
         self.is_impact = is_impact
-        self.dt_type = dt_type
         self.is_key_attribute = is_key_attribute
         self.dashboard_order = dashboard_order
 
@@ -58,7 +55,6 @@ class Attribute(ABC):
             "is_discrete": self.is_discrete,
             "is_kpi": self.is_kpi,
             "is_impact": self.is_impact,
-            "dt_type": self.dt_type,
             "is_key_attribute": self.is_key_attribute,
             "dashboard_order": self.dashboard_order,
         }
@@ -72,7 +68,6 @@ class MetricAttribute(Attribute):
                  is_discrete: bool = False,
                  is_kpi: bool = False,
                  is_impact: bool = False,
-                 dt_type: str = None,
                  is_key_attribute: bool = False,
                  dashboard_order: int = None):
         """
@@ -88,12 +83,10 @@ class MetricAttribute(Attribute):
         'Self - Health Score' metric, which can affect the 'Anomalies' Badge.
         :param is_impact: If set, this attribute will never be the 'root cause' of an issue. For example, it could be a
         proxy to a root cause, but not the root cause itself.
-        :param dt_type: The type of algorithm to use for dynamic thresholding.
         :param is_key_attribute: True if the attribute should be shown in some object summary widgets in the UI.
         :param dashboard_order: Determines the order parameters will be displayed in the UI.
         """
-        super().__init__(key, label, unit, is_rate, is_discrete, is_kpi, is_impact, dt_type, is_key_attribute,
-                         dashboard_order)
+        super().__init__(key, label, unit, is_rate, is_discrete, is_kpi, is_impact, is_key_attribute, dashboard_order)
 
     def to_json(self):
         return super().to_json() | {
@@ -111,7 +104,6 @@ class PropertyAttribute(Attribute):
                  is_discrete: bool = False,
                  is_kpi: bool = False,
                  is_impact: bool = False,
-                 dt_type: str = None,
                  is_key_attribute: bool = False,
                  dashboard_order: int = None):
         """
@@ -128,11 +120,10 @@ class PropertyAttribute(Attribute):
         'Self - Health Score' metric, which can affect the 'Anomalies' Badge.
         :param is_impact: If set, this attribute will never be the 'root cause' of an issue. For example, it could be a
         proxy to a root cause, but not the root cause itself.
-        :param dt_type: The type of algorithm to use for dynamic thresholding.
         :param is_key_attribute: True if the attribute should be shown in some object summary widgets in the UI.
         :param dashboard_order: Determines the order parameters will be displayed in the UI.
         """
-        super().__init__(key, label, unit, is_rate, is_discrete, is_kpi, is_impact, dt_type, is_key_attribute,
+        super().__init__(key, label, unit, is_rate, is_discrete, is_kpi, is_impact, is_key_attribute,
                          dashboard_order)
         self.is_string = is_string
 

--- a/lib/python/src/aria/ops/definition/credential_type.py
+++ b/lib/python/src/aria/ops/definition/credential_type.py
@@ -2,13 +2,17 @@
 #  SPDX-License-Identifier: Apache-2.0
 from abc import ABC
 from collections import OrderedDict
+from typing import Optional
 
 from aria.ops.definition.assertions import validate_key
 from aria.ops.definition.exceptions import DuplicateKeyException
 
 
 class CredentialParameter(ABC):
-    def __init__(self, key: str, label: str = None, required: bool = True, display_order: int = 0):
+    def __init__(self, key: str,
+                 label: Optional[str] = None,
+                 required: bool = True,
+                 display_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param label: Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
@@ -41,7 +45,10 @@ class CredentialIntParameter(CredentialParameter):
     :param display_order: Determines the order parameters will be displayed in the UI.
     """
 
-    def __init__(self, key: str, label: str = None, required: bool = True, display_order: int = 0):
+    def __init__(self, key: str,
+                 label: Optional[str] = None,
+                 required: bool = True,
+                 display_order: int = 0):
         super().__init__(key, label, required, display_order)
 
     def to_json(self):
@@ -51,7 +58,10 @@ class CredentialIntParameter(CredentialParameter):
 
 
 class CredentialStringParameter(CredentialParameter):
-    def __init__(self, key: str, label: str = None, required: bool = True, display_order: int = 0):
+    def __init__(self, key: str,
+                 label: Optional[str] = None,
+                 required: bool = True,
+                 display_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param label: Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
@@ -67,7 +77,10 @@ class CredentialStringParameter(CredentialParameter):
 
 
 class CredentialPasswordParameter(CredentialParameter):
-    def __init__(self, key: str, label: str = None, required: bool = True, display_order: int = 0):
+    def __init__(self, key: str,
+                 label: Optional[str] = None,
+                 required: bool = True,
+                 display_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param label: Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
@@ -94,7 +107,11 @@ class CredentialEnumParameter(CredentialParameter):
     :param display_order: Determines the order parameters will be displayed in the UI.
     """
 
-    def __init__(self, key: str, values: list[str], label: str = None, default: str = None, required: bool = True,
+    def __init__(self, key: str,
+                 values: list[str],
+                 label: Optional[str] = None,
+                 default: Optional[str] = None,
+                 required: bool = True,
                  display_order: int = 0):
         super().__init__(key, label, required, display_order)
         self.values = values
@@ -112,7 +129,7 @@ class CredentialEnumParameter(CredentialParameter):
 
 
 class CredentialType:
-    def __init__(self, key, label=None):
+    def __init__(self, key: str, label: Optional[str] = None):
         self.key = validate_key(key, "Credential type")
         self.label = label
         if label is None:
@@ -131,7 +148,7 @@ class CredentialType:
         self.add_parameter(field)
         return field
 
-    def define_int_parameter(self, key: str, label: str = None, required: bool = True):
+    def define_int_parameter(self, key: str, label: Optional[str] = None, required: bool = True):
         """
         Create a new int credential parameter and apply it to this credential definition.
         :param key: Used to identify the parameter.
@@ -143,7 +160,7 @@ class CredentialType:
         self.add_parameter(field)
         return field
 
-    def define_password_parameter(self, key: str, label: str = None, required: bool = True):
+    def define_password_parameter(self, key: str, label: Optional[str] = None, required: bool = True):
         """
         Create a new password credential parameter and apply it to this credential definition.
         :param key: Used to identify the parameter.
@@ -155,7 +172,10 @@ class CredentialType:
         self.add_parameter(field)
         return field
 
-    def define_enum_parameter(self, key: str, values: list[str], label: str = None, default: str = None,
+    def define_enum_parameter(self, key: str,
+                              values: list[str],
+                              label: Optional[str] = None,
+                              default: Optional[str] = None,
                               required: bool = True):
         """
         Create a new enum credential parameter and apply it to this credential definition.

--- a/lib/python/src/aria/ops/definition/group.py
+++ b/lib/python/src/aria/ops/definition/group.py
@@ -73,7 +73,6 @@ class GroupType(ABC):
                       is_discrete: bool = False,
                       is_kpi: bool = False,
                       is_impact: bool = False,
-                      dt_type: str = None,
                       is_key_attribute: bool = False) -> MetricAttribute:
         """
         :param key: Used to identify the parameter.
@@ -88,10 +87,9 @@ class GroupType(ABC):
         'Self - Health Score' metric, which can affect the 'Anomalies' Badge.
         :param is_impact: If set, this attribute will never be the 'root cause' of an issue. For example, it could be a
         proxy to a root cause, but not the root cause itself.
-        :param dt_type: The type of algorithm to use for dynamic thresholding.
         :param is_key_attribute: True if the attribute should be shown in some object summary widgets in the UI.
         """
-        metric = MetricAttribute(key, label, unit, is_rate, is_discrete, is_kpi, is_impact, dt_type, is_key_attribute,
+        metric = MetricAttribute(key, label, unit, is_rate, is_discrete, is_kpi, is_impact, is_key_attribute,
                                  dashboard_order=len(self.attributes))
         self.add_attribute(metric)
         return metric
@@ -103,7 +101,6 @@ class GroupType(ABC):
                                is_discrete: bool = False,
                                is_kpi: bool = False,
                                is_impact: bool = False,
-                               dt_type: str = None,
                                is_key_attribute: bool = False) -> PropertyAttribute:
         """
         :param key: Used to identify the parameter.
@@ -118,10 +115,9 @@ class GroupType(ABC):
         'Self - Health Score' metric, which can affect the 'Anomalies' Badge.
         :param is_impact: If set, this attribute will never be the 'root cause' of an issue. For example, it could be a
         proxy to a root cause, but not the root cause itself.
-        :param dt_type: The type of algorithm to use for dynamic thresholding.
         :param is_key_attribute: True if the attribute should be shown in some object summary widgets in the UI.
         """
-        _property = PropertyAttribute(key, label, True, unit, is_rate, is_discrete, is_kpi, is_impact, dt_type,
+        _property = PropertyAttribute(key, label, True, unit, is_rate, is_discrete, is_kpi, is_impact,
                                       is_key_attribute, dashboard_order=len(self.attributes))
         self.add_attribute(_property)
         return _property
@@ -133,7 +129,6 @@ class GroupType(ABC):
                                 is_discrete: bool = False,
                                 is_kpi: bool = False,
                                 is_impact: bool = False,
-                                dt_type: str = None,
                                 is_key_attribute: bool = False) -> PropertyAttribute:
         """
         :param key: Used to identify the parameter.
@@ -148,10 +143,9 @@ class GroupType(ABC):
         'Self - Health Score' metric, which can affect the 'Anomalies' Badge.
         :param is_impact: If set, this attribute will never be the 'root cause' of an issue. For example, it could be a
         proxy to a root cause, but not the root cause itself.
-        :param dt_type: The type of algorithm to use for dynamic thresholding.
         :param is_key_attribute: True if the attribute should be shown in some object summary widgets in the UI.
         """
-        _property = PropertyAttribute(key, label, False, unit, is_rate, is_discrete, is_kpi, is_impact, dt_type,
+        _property = PropertyAttribute(key, label, False, unit, is_rate, is_discrete, is_kpi, is_impact,
                                       is_key_attribute, dashboard_order=len(self.attributes))
         self.add_attribute(_property)
         return _property

--- a/lib/python/src/aria/ops/definition/group.py
+++ b/lib/python/src/aria/ops/definition/group.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from collections import OrderedDict
+from typing import Optional
 
 from aria.ops.definition.assertions import validate_key
 from aria.ops.definition.attribute import PropertyAttribute, MetricAttribute, Attribute
@@ -17,7 +18,7 @@ class GroupType(ABC):
         self.attributes = OrderedDict()
         self.groups = OrderedDict()
 
-    def define_group(self, key: str, label: str = None) -> Group:
+    def define_group(self, key: str, label: Optional[str] = None) -> Group:
         """
         Create a new group that can hold attributes and subgroups.
         :param key: The key for the group.
@@ -28,7 +29,7 @@ class GroupType(ABC):
         self.add_group(group)
         return group
 
-    def define_instanced_group(self, key: str, label: str = None, instance_required: bool = True) -> Group:
+    def define_instanced_group(self, key: str, label: Optional[str] = None, instance_required: bool = True) -> Group:
         """
         Create a new group that can hold attributes and subgroups. This group can be 'instanced', with a value, so that
         its subgroups and attributes can appear multiple times, once for each instance value. For example, a group
@@ -66,8 +67,8 @@ class GroupType(ABC):
         self.groups[key] = group
 
     def define_metric(self, key: str,
-                      label: str = None,
-                      unit: Unit = None,
+                      label: Optional[str] = None,
+                      unit: Optional[Unit] = None,
                       is_rate: bool = False,
                       is_discrete: bool = False,
                       is_kpi: bool = False,
@@ -96,8 +97,8 @@ class GroupType(ABC):
         return metric
 
     def define_string_property(self, key: str,
-                               label: str = None,
-                               unit: Unit = None,
+                               label: Optional[str] = None,
+                               unit: Optional[Unit] = None,
                                is_rate: bool = False,
                                is_discrete: bool = False,
                                is_kpi: bool = False,
@@ -126,8 +127,8 @@ class GroupType(ABC):
         return _property
 
     def define_numeric_property(self, key: str,
-                                label: str = None,
-                                unit: Unit = None,
+                                label: Optional[str] = None,
+                                unit: Optional[Unit] = None,
                                 is_rate: bool = False,
                                 is_discrete: bool = False,
                                 is_kpi: bool = False,
@@ -184,7 +185,7 @@ class GroupType(ABC):
 
 
 class Group(GroupType):
-    def __init__(self, key: str, label: str = None, instanced: bool = False, instance_required: bool = True):
+    def __init__(self, key: str, label: Optional[str] = None, instanced: bool = False, instance_required: bool = True):
         """
         Create a new group that can hold attributes and subgroups.
         :param key: The key for the group.

--- a/lib/python/src/aria/ops/definition/object_type.py
+++ b/lib/python/src/aria/ops/definition/object_type.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from typing import Optional
 
 from aria.ops.definition.assertions import validate_key
 from aria.ops.definition.exceptions import DuplicateKeyException
@@ -13,7 +14,7 @@ from aria.ops.definition.parameter import EnumParameter, IntParameter, StringPar
 class ObjectType(GroupType):
     def __init__(self,
                  key: str,
-                 label: str = None):
+                 label: Optional[str] = None):
         """
         Create a new object type definition
         :param key: The key of the object type
@@ -26,8 +27,11 @@ class ObjectType(GroupType):
         self.identifiers = OrderedDict()
         super().__init__()
 
-    def define_string_identifier(self, key: str, label: str = None, required: bool = True, is_part_of_uniqueness: bool = True,
-                                 default: str = None) -> ObjectType:
+    def define_string_identifier(self, key: str,
+                                 label: Optional[str] = None,
+                                 required: bool = True,
+                                 is_part_of_uniqueness: bool = True,
+                                 default: Optional[str] = None) -> ObjectType:
         """
         Create a new string identifier and apply it to this object type definition.
         All identifiers marked as 'part of uniqueness' are used to determine object identification. If none exist, the 
@@ -44,8 +48,11 @@ class ObjectType(GroupType):
         self.add_identifier(parameter)
         return self
 
-    def define_int_identifier(self, key: str, label: str = None, required: bool = True, is_part_of_uniqueness: bool = True,
-                              default: int = None) -> ObjectType:
+    def define_int_identifier(self, key: str,
+                              label: Optional[str] = None,
+                              required: bool = True,
+                              is_part_of_uniqueness: bool = True,
+                              default: Optional[int] = None) -> ObjectType:
         """
         Create a new int identifier and apply it to this object type definition.
         All identifiers marked 'part of uniqueness' are used to determine object identification. If none exist, the 
@@ -62,8 +69,12 @@ class ObjectType(GroupType):
         self.add_identifier(parameter)
         return self
 
-    def define_enum_identifier(self, key: str, values: list[str], label: str = None, required: bool = True,
-                               is_part_of_uniqueness: bool = True, default: str = None) -> ObjectType:
+    def define_enum_identifier(self, key: str,
+                               values: list[str],
+                               label: Optional[str] = None,
+                               required: bool = True,
+                               is_part_of_uniqueness: bool = True,
+                               default: Optional[str] = None) -> ObjectType:
         """
         Create a new enum identifier and apply it to this object type definition.
         All identifiers marked as 'part of uniqueness' are used to determine object identification. If none exist, the 

--- a/lib/python/src/aria/ops/definition/parameter.py
+++ b/lib/python/src/aria/ops/definition/parameter.py
@@ -71,7 +71,7 @@ class IntParameter(Parameter):
     def to_json(self):
         return super().to_json() | {
             "type": "integer",
-            "default": str(self.default) if self.default else None,
+            "default": str(self.default) if self.default is not None else None,
         }
 
 

--- a/lib/python/src/aria/ops/definition/parameter.py
+++ b/lib/python/src/aria/ops/definition/parameter.py
@@ -65,7 +65,7 @@ class IntParameter(Parameter):
     def to_json(self):
         return super().to_json() | {
             "type": "integer",
-            "default": str(self.default),
+            "default": str(self.default) if self.default else None,
         }
 
 
@@ -89,7 +89,7 @@ class StringParameter(Parameter):
         return super().to_json() | {
             "type": "string",
             "length": int(self.max_length),
-            "default": str(self.default)
+            "default": self.default
         }
 
 
@@ -119,5 +119,5 @@ class EnumParameter(Parameter):
             "type": "string",
             "enum": True,
             "enum_values": [str(value) for value in self.values],
-            "default": str(self.default)
+            "default": self.default
         }

--- a/lib/python/src/aria/ops/definition/parameter.py
+++ b/lib/python/src/aria/ops/definition/parameter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from typing import Optional
 
 from aria.ops.definition.assertions import validate_key
 from aria.ops.definition.exceptions import DuplicateKeyException
@@ -11,9 +12,9 @@ from aria.ops.definition.exceptions import DuplicateKeyException
 class Parameter(ABC):
     def __init__(self,
                  key: str,
-                 label: str = None,
-                 description: str = None,
-                 default: str = None,
+                 label: Optional[str] = None,
+                 description: Optional[str] = None,
+                 default: Optional[str | int] = None,
                  required: bool = True,
                  advanced: bool = False,
                  display_order: int = 0):
@@ -49,8 +50,13 @@ class Parameter(ABC):
 
 
 class IntParameter(Parameter):
-    def __init__(self, key: str, label: str = None, description: str = None, default: int = None, required: bool = True,
-                 advanced: bool = False, display_order: int = 0):
+    def __init__(self, key: str,
+                 label: Optional[str] = None,
+                 description: Optional[str] = None,
+                 default: Optional[int] = None,
+                 required: bool = True,
+                 advanced: bool = False,
+                 display_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param label: Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
@@ -70,8 +76,14 @@ class IntParameter(Parameter):
 
 
 class StringParameter(Parameter):
-    def __init__(self, key: str, label: str = None, description: str = None, default: str = None,
-                 max_length: int = 512, required: bool = True, advanced: bool = False, display_order: int = 0):
+    def __init__(self, key: str,
+                 label: Optional[str] = None,
+                 description: Optional[str] = None,
+                 default: Optional[str] = None,
+                 max_length: int = 512,
+                 required: bool = True,
+                 advanced: bool = False,
+                 display_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param label: Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
@@ -94,8 +106,14 @@ class StringParameter(Parameter):
 
 
 class EnumParameter(Parameter):
-    def __init__(self, key: str, values: list[str], label: str = None, description: str = None,
-                 default: str = None, required: bool = True, advanced: bool = False, display_order: int = 0):
+    def __init__(self, key: str,
+                 values: list[str],
+                 label: Optional[str] = None,
+                 description: Optional[str] = None,
+                 default: Optional[str] = None,
+                 required: bool = True,
+                 advanced: bool = False,
+                 display_order: int = 0):
         """
         :param key: Used to identify the parameter.
         :param values: An array containing all enum values. If 'default' is specified and not part of this array, it

--- a/lib/python/tests/definition/test_group_definition.py
+++ b/lib/python/tests/definition/test_group_definition.py
@@ -125,7 +125,7 @@ def test_duplicate_attribute_keys_not_allowed(group):
 
 
 def test_define_integer_metric(group):
-    group.define_metric("A", "B", Units.DATA_SIZE.BYTE, True, True, True, True, "multinomial", True)
+    group.define_metric("A", "B", Units.DATA_SIZE.BYTE, True, True, True, True, True)
     assert len(group.attributes) == 1
     assert group.attributes["A"].to_json() == {
         "key": "A",
@@ -136,7 +136,6 @@ def test_define_integer_metric(group):
         "data_type": "integer",  # derived from is_discrete = True
         "is_kpi": True,
         "is_impact": True,
-        "dt_type": "multinomial",
         "is_key_attribute": True,
         "is_property": False,
         "dashboard_order": 0
@@ -144,7 +143,7 @@ def test_define_integer_metric(group):
 
 
 def test_define_float_metric(group):
-    group.define_metric("A", "B", Units.RATIO.PERCENT, False, False, False, False, "polynomial", False)
+    group.define_metric("A", "B", Units.RATIO.PERCENT, False, False, False, False, False)
     assert len(group.attributes) == 1
     assert group.attributes["A"].to_json() == {
         "key": "A",
@@ -155,7 +154,6 @@ def test_define_float_metric(group):
         "data_type": "float",  # derived from is_discrete = False
         "is_kpi": False,
         "is_impact": False,
-        "dt_type": "polynomial",
         "is_key_attribute": False,
         "is_property": False,
         "dashboard_order": 0
@@ -163,7 +161,7 @@ def test_define_float_metric(group):
 
 
 def test_define_string_property(group):
-    group.define_string_property("A", "B", None, False, True, True, True, "multinomial", True)
+    group.define_string_property("A", "B", None, False, True, True, True, True)
     assert len(group.attributes) == 1
     assert group.attributes["A"].to_json() == {
         "key": "A",
@@ -174,7 +172,6 @@ def test_define_string_property(group):
         "data_type": "string",
         "is_kpi": True,
         "is_impact": True,
-        "dt_type": "multinomial",
         "is_key_attribute": True,
         "is_property": True,
         "dashboard_order": 0
@@ -182,7 +179,7 @@ def test_define_string_property(group):
 
 
 def test_define_numeric_property_1(group):
-    group.define_numeric_property("A", "B", Units.MISC.RACK_UNIT, False, True, True, True, "", True)
+    group.define_numeric_property("A", "B", Units.MISC.RACK_UNIT, False, True, True, True, True)
     assert len(group.attributes) == 1
     assert group.attributes["A"].to_json() == {
         "key": "A",
@@ -193,7 +190,6 @@ def test_define_numeric_property_1(group):
         "data_type": "integer",
         "is_kpi": True,
         "is_impact": True,
-        "dt_type": "",
         "is_key_attribute": True,
         "is_property": True,
         "dashboard_order": 0
@@ -201,7 +197,7 @@ def test_define_numeric_property_1(group):
 
 
 def test_define_numeric_property_2(group):
-    group.define_numeric_property("A", "B", Units.FREQUENCY.GIGAHERTZ, False, False, True, True, "polynomial", True)
+    group.define_numeric_property("A", "B", Units.FREQUENCY.GIGAHERTZ, False, False, True, True, True)
     assert len(group.attributes) == 1
     assert group.attributes["A"].to_json() == {
         "key": "A",
@@ -212,7 +208,6 @@ def test_define_numeric_property_2(group):
         "data_type": "float",
         "is_kpi": True,
         "is_impact": True,
-        "dt_type": "polynomial",
         "is_key_attribute": True,
         "is_property": True,
         "dashboard_order": 0

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "urwid==2.1.2",
         "urwidtrees==1.0.3",
         "validators==0.20.0",
-        "vmware-aria-operations-integration-sdk-lib==0.4.1",
+        "vmware-aria-operations-integration-sdk-lib==0.4.3",
         "wcwidth==0.2.5",
         "websocket-client==1.3.3",
         "Werkzeug==2.2.2",

--- a/vrealize_operations_integration_sdk/adapter_template/adapter.py
+++ b/vrealize_operations_integration_sdk/adapter_template/adapter.py
@@ -169,7 +169,7 @@ def get_adapter_definition() -> AdapterDefinition:
     definition.define_int_parameter("container_memory_limit",
                                     label="Adapter Memory Limit (MB)",
                                     description="Sets the maximum amount of memory VMware Aria Operations can "
-                                                "allocate to the container running this adapter instance.u",
+                                                "allocate to the container running this adapter instance.",
                                     required=True,
                                     advanced=True,
                                     default=1024)

--- a/vrealize_operations_integration_sdk/describe.py
+++ b/vrealize_operations_integration_sdk/describe.py
@@ -186,8 +186,11 @@ def add_resource_kind(parent, resource_kind_json, names, type=1, credential_kind
 
 
 def add_identifier(parent, identifier_json, names):
+    default = identifier_json.get("default")
+    if default is None:
+        default = ""
     identifier_xml = SubElement(parent, ns("ResourceIdentifier"), attrib={
-        "default": identifier_json.get("default") or "",
+        "default": str(default),
         "key": identifier_json["key"],
         "nameKey": names.get_key(identifier_json["label"], identifier_json.get("description")),
         "required": str(identifier_json["required"]).lower(),

--- a/vrealize_operations_integration_sdk/describe.py
+++ b/vrealize_operations_integration_sdk/describe.py
@@ -187,6 +187,7 @@ def add_resource_kind(parent, resource_kind_json, names, type=1, credential_kind
 
 def add_identifier(parent, identifier_json, names):
     identifier_xml = SubElement(parent, ns("ResourceIdentifier"), attrib={
+        "default": identifier_json.get("default", ""),
         "key": identifier_json["key"],
         "nameKey": names.get_key(identifier_json["label"], identifier_json.get("description")),
         "required": str(identifier_json["required"]).lower(),
@@ -204,7 +205,7 @@ def add_enum_values(parent, identifier_json):
         for value in identifier_json["enum_values"]:
             SubElement(parent, ns("enum"), attrib={
                 "value": str(value),
-                "default": str(value == identifier_json.get("default", None)).lower()
+                "default": str(value == identifier_json.get("default", False)).lower()
             })
 
 

--- a/vrealize_operations_integration_sdk/describe.py
+++ b/vrealize_operations_integration_sdk/describe.py
@@ -187,7 +187,7 @@ def add_resource_kind(parent, resource_kind_json, names, type=1, credential_kind
 
 def add_identifier(parent, identifier_json, names):
     identifier_xml = SubElement(parent, ns("ResourceIdentifier"), attrib={
-        "default": identifier_json.get("default", ""),
+        "default": identifier_json.get("default") or "",
         "key": identifier_json["key"],
         "nameKey": names.get_key(identifier_json["label"], identifier_json.get("description")),
         "required": str(identifier_json["required"]).lower(),
@@ -213,7 +213,7 @@ def add_attribute(parent, attribute_json, names):
     attribute_xml = SubElement(parent, ns("ResourceAttribute"), attrib={
         "key": attribute_json["key"],
         "nameKey": names.get_key(attribute_json["label"]),
-        "unit": attribute_json["unit"] or "",
+        "unit": attribute_json.get("unit") or "",
         "dashboardOrder": str(attribute_json["dashboard_order"]),
         "dataType": str(attribute_json["data_type"]),
         "isProperty": str(attribute_json["is_property"]).lower(),


### PR DESCRIPTION
In the case where a default value was null, the null value was being turned into a literal string (i.e., `"None"`). This fixes that issue, and adds the 'Optional' type to any parameters in definitions that are allowed to be null.

In addition:
* Adds support for default values to the describe.xml generation in the tooling
* Removes `dt_type` which is deprecated/unused in Aria Ops
* In some cases the `dashboard_parameter` defaulted to `0` and in others `None`. We now standardize on `0`.
* Removes a stray character in the `adapter.py` template