### PR TITLE
Fix incorrect default values for events

### DIFF
--- a/lib/python/src/aria/ops/event.py
+++ b/lib/python/src/aria/ops/event.py
@@ -32,12 +32,12 @@ class Event:
 
     message: str
     criticality: Criticality = Criticality.NONE
-    fault_key: str = (None,)
-    auto_cancel: bool = (False,)
-    start_date: int = (None,)
-    update_date: int = (None,)
-    cancel_date: int = (None,)
-    watch_wait_cycle: int = (1,)
+    fault_key: str = None
+    auto_cancel: bool = False
+    start_date: int = None
+    update_date: int = None
+    cancel_date: int = None
+    watch_wait_cycle: int = 1
     cancel_wait_cycle: int = 3
 
     def get_json(self):

--- a/lib/python/tests/test_event.py
+++ b/lib/python/tests/test_event.py
@@ -1,0 +1,15 @@
+#  Copyright 2022 VMware, Inc.
+#  SPDX-License-Identifier: Apache-2.0
+from aria.ops.event import Criticality
+from aria.ops.event import Event
+
+
+def test_minimal_event():
+    event = Event("name", Criticality.CRITICAL)
+    assert event.get_json() == {
+        "message": "name",
+        "criticality": 4,
+        "autoCancel": False,
+        "watchWaitCycle": 1,
+        "cancelWaitCycle": 3,
+    }


### PR DESCRIPTION
Originally, each of the default values for events had a comma after each declaration, which was incorrect but Python ignored. 

However, when `black` reformatted the codebase, it interpreted the commas as signifying python tuples and adjusted as such. This caused default values to become arrays when outputted to json, rather than single values. 

This PR restores correct functionality, and adds a simple test for verifying default values are working as intended.