### PR TITLE
Do not send authorization header when acquiring token

### DIFF
--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -1,6 +1,10 @@
 VMware Aria Operations Integration SDK Library
 ----------------------------------------------
-## 0.5.6 (12-9-2022)
+## 0.4.7 (01-13-2023)
+* Fix a bug where the 'Authorization' header was set with an empty token when 
+  acquiring a suite-api token, which in some cases resulted in 401 errors
+
+## 0.4.6 (12-9-2022)
 * Fix a bug where default values for Events were not set correctly
 
 ## 0.4.5 (11-17-2022)

--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vmware-aria-operations-integration-sdk-lib
-version = 0.4.6
+version = 0.4.7
 author = VMware, Inc.
 author_email = krokos@vmware.com
 description = Object model for interacting with the VMware Aria Operations Containerized API

--- a/lib/python/src/aria/ops/suite_api_client.py
+++ b/lib/python/src/aria/ops/suite_api_client.py
@@ -263,7 +263,8 @@ class SuiteApiClient(object):
     def _to_vrops_request(self, url: str, **kwargs: Any) -> dict:
         kwargs.setdefault("url", url)
         kwargs.setdefault("headers", {})
-        kwargs["headers"]["Authorization"] = "vRealizeOpsToken " + self.token
+        if self.token:
+            kwargs["headers"]["Authorization"] = "vRealizeOpsToken " + self.token
         kwargs["headers"].setdefault("Accept", "application/json")
         kwargs.setdefault("verify", False)
         if kwargs["url"].startswith("http"):


### PR DESCRIPTION
When acquiring a token, if the authorization header is set then Aria Ops Cloud will reject the request with a 401 unauthorized error. Interestingly, Aria Ops on-prem will accept the request with or without the header.