### PR TITLE
Feature/log rotation

### DIFF
--- a/images/base-python-adapter/swagger_server/__main__.py
+++ b/images/base-python-adapter/swagger_server/__main__.py
@@ -1,29 +1,18 @@
 #!/usr/bin/env python3
 #  Copyright 2022 VMware, Inc.
 #  SPDX-License-Identifier: Apache-2.0
-import logging
 import os
 
 import connexion
+import server_logging
 from cheroot import wsgi
 from cheroot.ssl.builtin import BuiltinSSLAdapter
 from swagger_server import encoder
 
 
-def main():
-    try:
-        logging.basicConfig(
-            filename="/var/log/server.log",
-            filemode="a",
-            format="%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s",
-            datefmt="%H:%M:%S",
-            level=logging.DEBUG,
-        )
-        logger = logging.getLogger("waitress")
-        logger.setLevel(logging.DEBUG)
-    except Exception as e:
-        logging.basicConfig(level=logging.CRITICAL + 1)
-    logger = logging.getLogger("main")
+def main() -> None:
+    server_logging.setup_logging("server.log")
+    logger = server_logging.getLogger("main")
 
     app = connexion.App(__name__, specification_dir="swagger/")
     app.app.json_encoder = encoder.JSONEncoder

--- a/images/base-python-adapter/swagger_server/server_logging.py
+++ b/images/base-python-adapter/swagger_server/server_logging.py
@@ -1,0 +1,86 @@
+#  Copyright 2023 VMware, Inc.
+#  SPDX-License-Identifier: Apache-2.0
+import logging
+import os
+from configparser import ConfigParser
+from logging.handlers import RotatingFileHandler
+from typing import Optional
+
+log_handler: Optional[RotatingFileHandler] = None
+
+
+def setup_logging(
+    filename: str, file_count: int = 5, max_size: int = 10_485_760
+) -> None:
+    """
+    :param filename The name of the file to log to
+    :param file_count The total number of files to retain. Defaults to 5.
+    :param max_size The maximum size in bytes of each file before the file
+                automatically rotates to a new one. Defaults to '10_485_760' (10 MiB).
+    """
+    try:
+        global log_handler
+        log_handler = RotatingFileHandler(
+            os.path.join(os.sep, "var", "log", filename),
+            maxBytes=max_size,
+            backupCount=file_count,
+        )
+        logging.basicConfig(
+            format="%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+            level=_get_default_log_level(),
+            handlers=[log_handler],
+        )
+        _set_log_levels()
+    except Exception:
+        logging.basicConfig(level=logging.CRITICAL + 1)
+
+
+def _get_default_log_level(default_level: int = logging.INFO) -> int:
+    default_level_name = logging.getLevelName(default_level)
+    log_config_file = os.path.join(os.sep, "var", "log", "loglevels.cfg")
+    config = ConfigParser()
+    if os.path.isfile(log_config_file):
+        config.read(log_config_file)
+    modified = False
+    if "server" not in config["DEFAULT"]:
+        modified = True
+        config["DEFAULT"].update({"server": default_level_name})
+    if "server" not in config:
+        modified = True
+        config["server"] = {
+            "main": logging.getLevelName(default_level),
+            "waitress": logging.getLevelName(logging.DEBUG),
+        }
+    if modified:
+        with open(log_config_file, "w") as config_file:
+            config.write(config_file)
+    try:
+        return int(
+            logging.getLevelName(config["DEFAULT"].get("server", default_level_name))
+        )
+    except ValueError:
+        return default_level
+
+
+def _set_log_levels() -> None:
+    log_config_file = os.path.join(os.sep, "var", "log", "loglevels.cfg")
+    config = ConfigParser()
+    config.read(log_config_file)
+    for logger in config["server"]:
+        logging.getLogger(logger).setLevel(config["server"][logger])
+
+
+def getLogger(name: str) -> logging.Logger:
+    # convenience function to avoid having to import logging and server_logging
+    return logging.getLogger(name)
+
+
+def rotate() -> None:
+    """
+    Rotates the current server logs to their backups (e.g., `server.log` to
+    `server.log.1`) and starts logging to the new server.log file.
+    :return: None
+    """
+    if log_handler:
+        log_handler.doRollover()

--- a/images/base-python-adapter/swagger_server/server_logging.py
+++ b/images/base-python-adapter/swagger_server/server_logging.py
@@ -50,7 +50,6 @@ def _get_default_log_level(default_level: int = logging.INFO) -> int:
         modified = True
         config["server"] = {
             "main": logging.getLevelName(default_level),
-            "waitress": logging.getLevelName(logging.DEBUG),
         }
     if modified:
         with open(log_config_file, "w") as config_file:

--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -1,5 +1,11 @@
 VMware Aria Operations Integration SDK Library
 ----------------------------------------------
+=======
+## Unreleased
+* Add a 'adapter_logging' module simplify logging in adapters
+* Add python logging handler 'NullLogger' as the default logger, to suppress 
+  messages if the calling adapter has not set up logging
+
 ## 0.4.7 (01-13-2023)
 * Fix a bug where the 'Authorization' header was set with an empty token when 
   acquiring a suite-api token, which in some cases resulted in 401 errors
@@ -25,7 +31,7 @@ VMware Aria Operations Integration SDK Library
 * Remove 'dt_type' from Metrics/Properties, as it is no longer used by Aria Ops
 
 ## 0.4.2 (11-02-2022)
-* Fix retreival of SuiteAPI credentials
+* Fix retrieval of SuiteAPI credentials
 
 ## 0.4.1 (11-02-2022)
 * Add paging to SuiteAPIClient

--- a/lib/python/src/aria/ops/__init__.py
+++ b/lib/python/src/aria/ops/__init__.py
@@ -1,2 +1,8 @@
 #  Copyright 2022 VMware, Inc.
 #  SPDX-License-Identifier: Apache-2.0
+import logging
+from logging import NullHandler
+
+# Add a null handler to avoid 'No Handler Found' warnings if the library user hasn't
+# configured their own.
+logging.getLogger(__name__).addHandler(NullHandler())

--- a/lib/python/src/aria/ops/adapter_logging.py
+++ b/lib/python/src/aria/ops/adapter_logging.py
@@ -66,8 +66,8 @@ def _set_log_levels() -> None:
     log_config_file = os.path.join(os.sep, "var", "log", "loglevels.cfg")
     config = ConfigParser()
     config.read(log_config_file)
-    for logger in config["server"]:
-        logging.getLogger(logger).setLevel(config["server"][logger])
+    for logger in config["adapter"]:
+        logging.getLogger(logger).setLevel(config["adapter"][logger])
 
 
 def getLogger(name: str) -> logging.Logger:

--- a/lib/python/src/aria/ops/definition/adapter_logging.py
+++ b/lib/python/src/aria/ops/definition/adapter_logging.py
@@ -1,0 +1,70 @@
+#  Copyright 2023 VMware, Inc.
+#  SPDX-License-Identifier: Apache-2.0
+import logging
+import os
+from configparser import ConfigParser
+from logging.handlers import RotatingFileHandler
+from typing import Optional
+
+log_handler: Optional[RotatingFileHandler] = None
+
+
+def setup_logging(filename: str, file_count: int = 5, max_size: int = 0) -> None:
+    """
+    :param filename The name of the file to log to
+    :param file_count The total number of files to retain. Defaults to 5.
+    :param max_size The maximum size in bytes of each file before the file
+                    automatically rotates to a new one. Defaults to '0', which will
+                    do no automatic rotation. Requires calling the 'rotate()' function
+                    manually to ensure logs do not become too large.
+    """
+    try:
+        global log_handler
+        log_handler = RotatingFileHandler(
+            os.path.join(os.sep, "var", "log", filename),
+            maxBytes=max_size,
+            backupCount=file_count,
+        )
+        logging.basicConfig(
+            format="%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+            level=_get_level("DEFAULT"),
+            handlers=[log_handler],
+        )
+    except Exception:
+        logging.basicConfig(level=logging.CRITICAL + 1)
+
+
+def _get_level(name: str, default_level: int = logging.INFO) -> int:
+    log_config_file = os.path.join(os.sep, "var", "log", "loglevels.cfg")
+    if not os.path.isfile(log_config_file):
+        new_config = ConfigParser()
+        new_config["DEFAULT"] = {"level": logging.getLevelName(default_level)}
+        with open(log_config_file, "w") as config_file:
+            new_config.write(config_file)
+    config = ConfigParser()
+    config.read(log_config_file)
+    try:
+        if name in config and "level" in config[name]:
+            return int(logging.getLevelName(config[name].get("level")))
+        elif "DEFAULT" in config:
+            return int(
+                logging.getLevelName(
+                    config["DEFAULT"].get("level", logging.getLevelName(default_level))
+                )
+            )
+        else:
+            return default_level
+    except ValueError:
+        return default_level
+
+
+def getLogger(name: str, default_level: int = logging.INFO) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.setLevel(_get_level(name, default_level))
+    return logger
+
+
+def rotate() -> None:
+    if log_handler:
+        log_handler.doRollover()

--- a/lib/python/src/aria/ops/pipe_utils.py
+++ b/lib/python/src/aria/ops/pipe_utils.py
@@ -7,7 +7,7 @@ import logging
 from typing import Optional
 from typing import Union
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 def read_from_pipe(input_pipe: str) -> Optional[dict | list]:


### PR DESCRIPTION
* Adds log rotation to adapter.log and server.log
* Adds date to timestamps in logs
* Adds support for an auto-generated `loglevels.cfg` file in the logs directory for controlling log output

Next steps:
1. release the sdk lib and regenerate the server images
2. update the template `adapter.py` in the SDK in a separate MR once `1` is complete
3. update the aria apps MP to use the new SDK lib and image in a separate MR once `1` is complete

Resolves [37514](https://jira.eng.vmware.com/browse/VOPERATION-37514) once `1` and `2` are complete.
Resolves [38208](https://jira.eng.vmware.com/browse/VOPERATION-38208), [38083](https://jira.eng.vmware.com/browse/VOPERATION-38083) once `3` is complete

Example `loglevels.cfg` file:
```
[DEFAULT]
server = INFO
adapter = DEBUG

[server]
main = INFO
waitress = DEBUG

[adapter]
__main__ = DEBUG
aoa_client = WARNING
node = INFO
```

Example `adapter.log` (truncated) with above settings:
```
2023-01-25 15:33:35,694 __main__ DEBUG Running adapter code with arguments: ['collect', '/tmp/tmpzet_tajt/input_pipe', '/tmp/tmpzet_tajt/output_pipe']
2023-01-25 15:33:35,694 /home/aria-ops-adapter-user/.local/lib/python3.10/site-packages/aria/ops/pipe_utils.py DEBUG Input Pipe: /tmp/tmpzet_tajt/input_pipe
2023-01-25 15:33:35,695 /home/aria-ops-adapter-user/.local/lib/python3.10/site-packages/aria/ops/pipe_utils.py DEBUG Opened /tmp/tmpzet_tajt/input_pipe
2023-01-25 15:33:35,696 asyncio DEBUG Using selector: EpollSelector
2023-01-25 15:33:35,697 __main__ DEBUG Starting collection
2023-01-25 15:33:35,704 __main__ DEBUG Adding clusters
2023-01-25 15:33:36,153 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660515706&q=rawsum%28ts%28kubernetes.cluster.cpu.usage_rate%29%2C+cluster%29&e=1674660815706 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,174 __main__ DEBUG Done adding clusters: 0.4687063694000244
2023-01-25 15:33:36,176 __main__ DEBUG Adding nodes
2023-01-25 15:33:36,275 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516177&q=%0A++++++++rawsum%28%0A++++++++++++join%28%0A++++++++++++++++ts%28kubernetes.node.info%29+AS+ts1+RIGHT+JOIN%0A++++++++++++++++ts%28kubernetes.node.cpu.limit%29+AS+ts2+USING%28nodename%29%2C%0A++++++++++++++++source%3Dts2.source%2C%0A++++++++++++++++internal_ip%3Dts1.internal_ip%2C%0A++++++++++++++++provider_id%3Dts1.provider_id%2C%0A++++++++++++++++nodename%3Dts2.nodename%2C%0A++++++++++++++++cluster%3Dts2.cluster%2C%0A++++++++++++++++node_role%3Dts2.node_role%2C%0A++++++++++++++++ts2%0A++++++++++++%29%2C%0A++++++++++++nodename%2C+cluster%2C+internal_ip%2C+provider_id%2C+node_role%0A++++++++%29%0A++++++++&e=1674660816177 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,426 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516336&q=align%285m%2C+ts%28kubernetes.node.cpu.node_allocatable%2C+nodename+and+cluster%29%29&e=1674660816336 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,679 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516337&q=align%285m%2Cts%28kubernetes.node.cpu.node_reservation%2C+nodename+and+cluster%29%29&e=1674660816337 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,683 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516337&q=align%285m%2Cts%28kubernetes.node.cpu.node_utilization%2C+nodename+and+cluster%29%29&e=1674660816337 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,691 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516336&q=align%285m%2Cts%28kubernetes.node.cpu.node_capacity%2C+nodename+and+cluster%29%29&e=1674660816336 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,693 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516340&q=ts%28kubernetes.node.status.condition%2C+condition%3DReady%29&e=1674660816340 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,694 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516339&q=align%285m%2Cts%28kubernetes.node.filesystem.available%2C+nodename+and+cluster%29%29&e=1674660816339 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,696 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516338&q=align%285m%2Cts%28kubernetes.node.memory.node_reservation%2C+nodename+and+cluster%29%29&e=1674660816338 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,703 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516337&q=align%285m%2Cts%28kubernetes.node.memory.node_allocatable%2C+nodename+and+cluster%29%29&e=1674660816337 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,705 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516338&q=align%285m%2Cts%28kubernetes.node.memory.node_capacity%2C+nodename+and+cluster%29%29&e=1674660816338 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,708 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516339&q=%0A++++++++++++align%285m%2C%0A++++++++++++++++ts%28kubernetes.node.memory.working_set%2C+nodename+and+cluster%29%0A++++++++++++++++%2F+ts%28kubernetes.node.memory.node_allocatable%2C+nodename+and+cluster%29%0A++++++++++++%29%0A++++++++++++&e=1674660816339 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,710 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516339&q=align%285m%2Cts%28kubernetes.node.filesystem.limit%2C+nodename+and+cluster%29%29&e=1674660816339 "HTTP/1.1 200 OK"
2023-01-25 15:33:36,718 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660516340&q=align%285m%2Cts%28kubernetes.node.filesystem.usage%2C+nodename+and+cluster%29%29&e=1674660816340 "HTTP/1.1 200 OK"
2023-01-25 15:33:37,643 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/alert "HTTP/1.1 200 OK"
2023-01-25 15:33:37,942 httpx._client DEBUG HTTP Request: POST https://nimba.wavefront.com/api/v2/search/alert "HTTP/1.1 200 OK"
2023-01-25 15:33:37,948 __main__ DEBUG Done adding nodes: 1.772817850112915
2023-01-25 15:33:37,950 __main__ DEBUG Adding namespaces
2023-01-25 15:33:38,37 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660517951&q=rawsum%28ts%28kubernetes.ns.cpu.usage_rate%29%2C+cluster%2C+namespace_name%29&e=1674660817951 "HTTP/1.1 200 OK"
2023-01-25 15:33:38,81 namespace DEBUG Found cluster for relating to namespaces: <cluster.Cluster object at 0x7f202fd39de0>
2023-01-25 15:33:38,82 namespace DEBUG Found cluster for relating to namespaces: <cluster.Cluster object at 0x7f202fd38f40>
2023-01-25 15:33:38,83 namespace DEBUG Created new namespace (kube-system) in cluster (scale-cluster)
2023-01-25 15:33:38,85 namespace DEBUG Created new namespace (kube-system) in cluster (kube-m.tvs.vmware.com)
2023-01-25 15:33:38,86 namespace DEBUG Created new namespace (wavefront-tvs) in cluster (kube-m.tvs.vmware.com)
2023-01-25 15:33:38,87 namespace DEBUG Created new namespace (observability-system) in cluster (scale-cluster)
2023-01-25 15:33:38,88 namespace DEBUG Created new namespace (default) in cluster (kube-m.tvs.vmware.com)
2023-01-25 15:33:38,89 __main__ DEBUG Done adding namespaces:0.13840007781982422
2023-01-25 15:33:38,90 __main__ DEBUG Adding deployments
2023-01-25 15:33:38,178 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660518092&q=rawsum%28ts%28kubernetes.deployment.available_replicas%29%2C+cluster%2C+namespace_name%2C+deployment%29&e=1674660818092 "HTTP/1.1 200 OK"
2023-01-25 15:33:38,184 deployment DEBUG Found namespace for relating to deployment: <namespace.Namespace object at 0x7f202ebdbe50>
2023-01-25 15:33:38,186 deployment DEBUG Found namespace for relating to deployment: <namespace.Namespace object at 0x7f202ebe7be0>
2023-01-25 15:33:38,187 deployment DEBUG Found namespace for relating to deployment: <namespace.Namespace object at 0x7f202ebf9c90>
2023-01-25 15:33:38,188 deployment DEBUG Found namespace for relating to deployment: <namespace.Namespace object at 0x7f202c0c1390>
2023-01-25 15:33:38,189 deployment DEBUG Found namespace for relating to deployment: <namespace.Namespace object at 0x7f202c0c15a0>
2023-01-25 15:33:38,190 deployment DEBUG Created new deployment (coredns) in namespace (kube-system)
2023-01-25 15:33:38,191 deployment DEBUG Created new deployment (my-load-generator) in namespace (default)
2023-01-25 15:33:38,192 deployment DEBUG Created new deployment (coredns) in namespace (kube-system)
2023-01-25 15:33:38,193 deployment DEBUG Created new deployment (wavefront-proxy) in namespace (observability-system)
2023-01-25 15:33:38,194 deployment DEBUG Created new deployment (wavefront-cluster-collector) in namespace (observability-system)
2023-01-25 15:33:38,195 deployment DEBUG Created new deployment (wavefront-tvs-proxy) in namespace (wavefront-tvs)
2023-01-25 15:33:38,196 deployment DEBUG Created new deployment (wavefront-controller-manager) in namespace (observability-system)
2023-01-25 15:33:38,197 __main__ DEBUG Done adding deployments: 0.10617327690124512
2023-01-25 15:33:38,198 __main__ DEBUG Adding replicasets
2023-01-25 15:33:38,288 httpx._client DEBUG HTTP Request: GET https://nimba.wavefront.com/api/v2/chart/api?s=1674660518200&q=rawsum%28ts%28kubernetes.replicaset.available_replicas%29%2C+cluster%2C+replicaset%2C+namespace_name%29&e=1674660818200 "HTTP/1.1 200 OK"
2023-01-25 15:33:38,293 replica_set DEBUG Found deployment for relating to replicaset: <deployment.Deployment object at 0x7f202c089750>
2023-01-25 15:33:38,294 replica_set DEBUG deployment: kube-system
2023-01-25 15:33:38,295 replica_set DEBUG Found deployment for relating to replicaset: <deployment.Deployment object at 0x7f202c0c3310>
```