### PR TITLE
Story/update python slim bullseye image

### DIFF
--- a/.github/workflows/aria-operations-integration-sdk.yaml
+++ b/.github/workflows/aria-operations-integration-sdk.yaml
@@ -10,10 +10,10 @@ jobs:
     name: Aria Operations Integration SDK
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -47,9 +47,9 @@ jobs:
     name: Aria Operations Integration SDK Python Library
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/images/base-python-adapter/Dockerfile
+++ b/images/base-python-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.2-slim-bullseye
+FROM python:3.11.1-slim-bullseye
 
 # Ensure that the /var/log directory is writable by the server/adapter
 RUN chmod 777 /var/log

--- a/images/java-adapter/Dockerfile
+++ b/images/java-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM base-adapter:python-0.9.3
+FROM base-adapter:python-0.10.0
 
 # manual java install to prevent overwriting previous dependencies
 # switch to root in oder to do all installs

--- a/images/powershell-adapter/Dockerfile
+++ b/images/powershell-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM base-adapter:python-0.9.3
+FROM base-adapter:python-0.10.0
 
 # manual powershell install to prevent overwritting previous dependecies
 # switch to root in oder to do all installs

--- a/vmware_aria_operations_integration_sdk/adapter_template/powershell.py
+++ b/vmware_aria_operations_integration_sdk/adapter_template/powershell.py
@@ -3,8 +3,7 @@
 import os
 
 
-def build_template(path: str, root_directory: str):
-
+def build_template(path: str, root_directory: str) -> None:
     with open(os.path.join(path, root_directory, "collector.ps1"), "w") as collector:
         collector.write(
             """

--- a/vmware_aria_operations_integration_sdk/container_versions.json
+++ b/vmware_aria_operations_integration_sdk/container_versions.json
@@ -2,19 +2,19 @@
     "base_image": {
         "language": "Python",
         "path": "base-python-adapter",
-        "version": "0.9.3"
+        "version": "0.10.0"
     },
     "registry_url": "projects.registry.vmware.com/vmware_aria_operations_integration_sdk",
     "secondary_images": [
         {
             "language": "Java",
             "path": "java-adapter",
-            "version": "0.7.3"
+            "version": "0.8.0"
         },
         {
             "language": "Powershell",
             "path": "powershell-adapter",
-            "version": "0.7.3"
+            "version": "0.8.0"
         }
     ]
 }

--- a/vmware_aria_operations_integration_sdk/mp_init.py
+++ b/vmware_aria_operations_integration_sdk/mp_init.py
@@ -375,7 +375,6 @@ def create_commands_file(
 ) -> None:
     logger.debug("generating commands file")
     with open(os.path.join(path, "commands.cfg"), "w") as commands:
-
         command_and_executable = ""
         if "java" == language:
             command_and_executable = (

--- a/vmware_aria_operations_integration_sdk/mp_test.py
+++ b/vmware_aria_operations_integration_sdk/mp_test.py
@@ -409,7 +409,7 @@ def display_ui(
 def write_validation_log(validation_file_path: str, result: Result) -> None:
     # TODO: create a test object to be able to write encapsulated test results
     with open(validation_file_path, "w") as validation_file:
-        for (severity, message) in result.messages:
+        for severity, message in result.messages:
             validation_file.write(f"{severity.name}: {message}\n")
 
 

--- a/vmware_aria_operations_integration_sdk/validation/describe_checks.py
+++ b/vmware_aria_operations_integration_sdk/validation/describe_checks.py
@@ -60,7 +60,6 @@ def cross_check_attribute(
         return result
 
     if child_type == "ResourceGroup":
-
         if is_true(match, "instanced") and is_true(match, "instanceRequired"):
             if not instanced:
                 result.with_warning(


### PR DESCRIPTION
Update to Python 3.11.1 with the latest slim-bullseye OS.

* Base Python image is now 0.10.0
* Java and Powershell are updated to use 0.10.0 version of base image
* Some 'black' checks now fail when running against 3.11 - these are fixed
* Added Python 3.11 to the GitHub actions CI