### PR TITLE
Story/library relationship improvements

### DIFF
--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -2,6 +2,12 @@ VMware Aria Operations Integration SDK Library
 ----------------------------------------------
 
 ## Unreleased
+* Adds 'RelationshipUpdateModes' enum to control how relationships are returned from 
+  'CollectResult'
+* Add 'get_object' and 'get_objects_by_type' helper methods in 'CollectResult'
+* Add 'adapter_type()' and 'object_type()' helper methods in 'Object'
+* Add 'has_content()' method in 'Object' that returns true if the object contains 
+  at least one metric, property, or event
 * Add 'collection_number' to Adapter Instance. Starts at 0 and increments each time 
   'collect' is called. Requires server based off of base-python-adapter 0.10.0 or 
   higher.

--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -2,6 +2,9 @@ VMware Aria Operations Integration SDK Library
 ----------------------------------------------
 
 ## Unreleased
+* If an AdapterDefinition is passed into a 'CollectResult', external object types
+  are no longer returned in the result unless they contain content. Relationships
+  are not affected. (Note: requires unreleased mp-test update)
 * Adds 'RelationshipUpdateModes' enum to control how relationships are returned from 
   'CollectResult'
 * Add 'get_object' and 'get_objects_by_type' helper methods in 'CollectResult'

--- a/lib/python/src/aria/ops/result.py
+++ b/lib/python/src/aria/ops/result.py
@@ -128,10 +128,10 @@ class RelationshipUpdateModes(Enum):  # type: ignore
     there are relationships between objects in the Result. All currently-existing
     relationships in VMware Aria Operations will be preserved.
 
-    If 'update_relationships' is 'AUTO' (or not explicitly set), then if any object
-    in the result has at least relationship, the mode will behave like 'ALL',
-    and if no objects have any relationships in the Result, the mode will behave like
-    'NONE'. This default behavior makes it easy to skip collecting all relationships
+    If 'update_relationships' is 'AUTO' (or not explicitly set), then the mode will
+    behave like 'ALL' if any object in the Result has at least one relationship,
+    otherwise the mode will behave like 'NONE' if no objects have any relationships in
+    the Result. This default behavior makes it easy to skip collecting all relationships
     for a collection without overwriting previously-collected relationships, e.g., for
     performance reasons.
 
@@ -141,7 +141,7 @@ class RelationshipUpdateModes(Enum):  # type: ignore
     'add_children'), existing child relationships in VMware Aria Operations will be
     preserved. This means that to remove all relationships from an object
     (without setting any new relationships), the adapter must call 'add_children' on
-    the object with an empty collection of children. This is useful for updating a
+    the object with an empty collection of children. This mode is useful for updating a
     subset of objects' relationships in a collection, but requires more care to
     ensure relationships are removed when appropriate.
     """

--- a/lib/python/src/aria/ops/result.py
+++ b/lib/python/src/aria/ops/result.py
@@ -121,30 +121,29 @@ RelationshipUpdateMode = NewType("RelationshipUpdateMode", int)
 class RelationshipUpdateModes(Enum):  # type: ignore
     """
     If 'update_relationships' is 'ALL', all relationships between objects are
-    returned.
+    returned. This mode will remove any currently-existing relationships in VMware
+    Aria Operations that are not present in the Result.
 
-    If 'update_relationships' is 'None', no relationships will be returned.
+    If 'update_relationships' is 'NONE', no relationships will be returned, even if
+    there are relationships between objects in the Result. All currently-existing
+    relationships in VMware Aria Operations will be preserved.
 
-    If 'update_relationships' is 'AUTO' (or not explicitly set), then all
-    relationships are returned _if and only if at least one object has set
-    relationships_.
+    If 'update_relationships' is 'AUTO' (or not explicitly set), then if any object
+    in the result has at least relationship, the mode will behave like 'ALL',
+    and if no objects have any relationships in the Result, the mode will behave like
+    'NONE'. This default behavior makes it easy to skip collecting all relationships
+    for a collection without overwriting previously-collected relationships, e.g., for
+    performance reasons.
 
     If 'update_relationships' is 'PER_OBJECT', then only objects with updated
-    relationships will be returned. Note: Any object that has not been updated
-    will retain existing relationships. This means that to remove all
-    relationships from an object (without setting any new relationships), the
-    adapter must call 'add_children' on the object with an empty collection of
-    children.
-
-    If an object's relationships are returned, but the object has no current
-    relationships, then any previously-existing relationships will be removed.
-
-    If an object's relationships are not returned, then any previously-existing
-    relationships will remain present in Aria Operations.
-
-    The default behavior makes it easy to skip collecting relationships for a
-    collection without overwriting previously-collected relationships, e.g.,
-    for performance reasons.
+    relationships will be returned. This is similar to 'AUTO' except that if an
+    object's child relationships have not been updated/set (by calling 'add_child' or
+    'add_children'), existing child relationships in VMware Aria Operations will be
+    preserved. This means that to remove all relationships from an object
+    (without setting any new relationships), the adapter must call 'add_children' on
+    the object with an empty collection of children. This is useful for updating a
+    subset of objects' relationships in a collection, but requires more care to
+    ensure relationships are removed when appropriate.
     """
 
     ALL = RelationshipUpdateMode(1)

--- a/lib/python/tests/test_collect_result.py
+++ b/lib/python/tests/test_collect_result.py
@@ -1,0 +1,361 @@
+#  Copyright 2023 VMware, Inc.
+#  SPDX-License-Identifier: Apache-2.0
+import copy
+from typing import Any
+from typing import Dict
+
+from aria.ops.definition.adapter_definition import AdapterDefinition
+from aria.ops.event import Criticality
+from aria.ops.result import CollectResult
+from aria.ops.result import RelationshipUpdateModes
+
+one_object_base_result: Dict[str, Any] = {
+    "nonExistingObjects": [],
+    "relationships": [],
+    "result": [
+        {
+            "events": [],
+            "key": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name",
+                "objectKind": "Object",
+            },
+            "metrics": [],
+            "properties": [],
+        }
+    ],
+}
+
+two_object_base_result: Dict[str, Any] = {
+    "nonExistingObjects": [],
+    "relationships": [],
+    "result": [
+        {
+            "events": [],
+            "key": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name1",
+                "objectKind": "Object",
+            },
+            "metrics": [],
+            "properties": [],
+        },
+        {
+            "events": [],
+            "key": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name2",
+                "objectKind": "Object",
+            },
+            "metrics": [],
+            "properties": [],
+        },
+    ],
+}
+
+
+def test_get_json_1_object() -> None:
+    result = CollectResult()
+    result.object("Adapter", "Object", "Name")
+    assert result.get_json() == one_object_base_result
+
+
+def test_get_json_1_object_with_metric() -> None:
+    result = CollectResult()
+    obj = result.object("Adapter", "Object", "Name")
+    obj.with_metric("metric", 1, 1000)
+    expected_result = copy.deepcopy(one_object_base_result)
+    expected_result["result"][0]["metrics"] = [
+        {"key": "metric", "numberValue": 1.0, "timestamp": 1000}
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_1_object_with_numeric_property() -> None:
+    result = CollectResult()
+    obj = result.object("Adapter", "Object", "Name")
+    obj.with_property("property", 1, 1000)
+    expected_result = copy.deepcopy(one_object_base_result)
+    expected_result["result"][0]["properties"] = [
+        {"key": "property", "numberValue": 1.0, "timestamp": 1000}
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_1_object_with_string_property() -> None:
+    result = CollectResult()
+    obj = result.object("Adapter", "Object", "Name")
+    obj.with_property("property", "string", 1000)
+    expected_result = copy.deepcopy(one_object_base_result)
+    expected_result["result"][0]["properties"] = [
+        {"key": "property", "stringValue": "string", "timestamp": 1000}
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_1_object_with_event() -> None:
+    result = CollectResult()
+    obj = result.object("Adapter", "Object", "Name")
+    obj.with_event("event message", Criticality.CRITICAL)
+    expected_result = copy.deepcopy(one_object_base_result)
+    expected_result["result"][0]["events"] = [
+        {
+            "autoCancel": False,
+            "cancelWaitCycle": 3,
+            "criticality": 4,
+            "message": "event message",
+            "watchWaitCycle": 1,
+        }
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_2_objects() -> None:
+    result = CollectResult()
+    result.object("Adapter", "Object", "Name1")
+    result.object("Adapter", "Object", "Name2")
+    assert result.get_json() == two_object_base_result
+
+
+def test_get_json_2_objects_one_external() -> None:
+    result = CollectResult(target_definition=AdapterDefinition("Adapter"))
+    result.object("Adapter", "Object", "Name")
+    result.object("Adapter1", "Object", "Name1")
+    # There are no metrics, properties, or events on external 'Adapter1' type,
+    # so we don't include it
+    assert result.get_json() == one_object_base_result
+
+
+def test_get_json_2_objects_one_external_with_metric() -> None:
+    result = CollectResult(target_definition=AdapterDefinition("Adapter"))
+    result.object("Adapter", "Object", "Name1")
+    ext_obj = result.object("Adapter1", "Object", "Name2")
+    ext_obj.with_metric("appended_metric", 1, 1000)
+    expected_result = copy.deepcopy(two_object_base_result)
+    # Because we added a metric to the external kind, it will be included
+    expected_result["result"][1]["key"]["adapterKind"] = "Adapter1"
+    expected_result["result"][1]["metrics"] = [
+        {"key": "appended_metric", "numberValue": 1.0, "timestamp": 1000}
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_2_objects_relationships_none() -> None:
+    # 'NONE' will not set relationships for any object
+    result = CollectResult()
+    result.update_relationships = RelationshipUpdateModes.NONE
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    assert result.get_json() == two_object_base_result
+
+
+def test_get_json_2_objects_relationships_none1() -> None:
+    # 'NONE' will not set relationships for any object, even if there are relationships
+    result = CollectResult()
+    result.update_relationships = RelationshipUpdateModes.NONE
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    obj1.add_child(obj2)
+    assert result.get_json() == two_object_base_result
+
+
+def test_get_json_2_objects_relationships_all() -> None:
+    result = CollectResult()
+    # 'ALL' will set relationships for each object
+    result.update_relationships = RelationshipUpdateModes.ALL
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    obj1.add_child(obj2)
+    expected_result = copy.deepcopy(two_object_base_result)
+    expected_result["relationships"] = [
+        {
+            "children": [
+                {
+                    "adapterKind": "Adapter",
+                    "identifiers": [],
+                    "name": "Name2",
+                    "objectKind": "Object",
+                }
+            ],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name1",
+                "objectKind": "Object",
+            },
+        },
+        {
+            "children": [],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name2",
+                "objectKind": "Object",
+            },
+        },
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_2_objects_relationships_all1() -> None:
+    result = CollectResult()
+    # 'ALL' will set relationships for each object, even if there are no relationships
+    result.update_relationships = RelationshipUpdateModes.ALL
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    expected_result = copy.deepcopy(two_object_base_result)
+    expected_result["relationships"] = [
+        {
+            "children": [],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name1",
+                "objectKind": "Object",
+            },
+        },
+        {
+            "children": [],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name2",
+                "objectKind": "Object",
+            },
+        },
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_2_objects_relationships_auto() -> None:
+    result = CollectResult()
+    # 'AUTO' will not set relationships for any objects if all objects have no
+    # relationships
+    result.update_relationships = RelationshipUpdateModes.AUTO
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    assert result.get_json() == two_object_base_result
+
+
+def test_get_json_2_objects_relationships_auto1() -> None:
+    result = CollectResult()
+    # 'AUTO' will set relationships for all objects if any object has at least one
+    # relationship
+    result.update_relationships = RelationshipUpdateModes.AUTO
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    obj1.add_child(obj2)
+
+    expected_result = copy.deepcopy(two_object_base_result)
+    expected_result["relationships"] = [
+        {
+            "children": [
+                {
+                    "adapterKind": "Adapter",
+                    "identifiers": [],
+                    "name": "Name2",
+                    "objectKind": "Object",
+                }
+            ],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name1",
+                "objectKind": "Object",
+            },
+        },
+        {
+            "children": [],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name2",
+                "objectKind": "Object",
+            },
+        },
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_2_objects_relationships_per_object() -> None:
+    result = CollectResult()
+    # 'PER_OBJECT' will not set relationships for any objects unless they have
+    # children
+    result.update_relationships = RelationshipUpdateModes.PER_OBJECT
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    assert result.get_json() == two_object_base_result
+
+
+def test_get_json_2_objects_relationships_per_object1() -> None:
+    result = CollectResult()
+    # 'PER_OBJECT' will set relationships for any objects that have children
+    result.update_relationships = RelationshipUpdateModes.PER_OBJECT
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    obj1.add_child(obj2)
+
+    expected_result = copy.deepcopy(two_object_base_result)
+    expected_result["relationships"] = [
+        {
+            "children": [
+                {
+                    "adapterKind": "Adapter",
+                    "identifiers": [],
+                    "name": "Name2",
+                    "objectKind": "Object",
+                }
+            ],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name1",
+                "objectKind": "Object",
+            },
+        }
+    ]
+    assert result.get_json() == expected_result
+
+
+def test_get_json_2_objects_relationships_per_object2() -> None:
+    result = CollectResult()
+    # 'PER_OBJECT' will only set no relationships on an object if they have explicitly
+    # added no children
+    result.update_relationships = RelationshipUpdateModes.PER_OBJECT
+    obj1 = result.object("Adapter", "Object", "Name1")
+    obj2 = result.object("Adapter", "Object", "Name2")
+    obj1.add_child(obj2)
+    obj2.add_children([])
+
+    expected_result = copy.deepcopy(two_object_base_result)
+    expected_result["relationships"] = [
+        {
+            "children": [
+                {
+                    "adapterKind": "Adapter",
+                    "identifiers": [],
+                    "name": "Name2",
+                    "objectKind": "Object",
+                }
+            ],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name1",
+                "objectKind": "Object",
+            },
+        },
+        {
+            "children": [],
+            "parent": {
+                "adapterKind": "Adapter",
+                "identifiers": [],
+                "name": "Name2",
+                "objectKind": "Object",
+            },
+        },
+    ]
+    assert result.get_json() == expected_result

--- a/vmware_aria_operations_integration_sdk/collection_statistics.py
+++ b/vmware_aria_operations_integration_sdk/collection_statistics.py
@@ -422,14 +422,23 @@ class CollectionStatistics:
                 self.obj_statistics[obj_id] = stats
                 self.obj_type_statistics[obj_id.objectKind].add_object(stats)
         for rel in json.get("relationships", []):
-            parent = _get_object_id(rel.get("parent"))
+            parent_dict = rel.get("parent")
+            parent = _get_object_id(parent_dict)
             children = rel.get("children", [])
-            for child in children:
-                child = _get_object_id(child)
+            for child_dict in children:
+                child = _get_object_id(child_dict)
                 if child and parent:
                     key = (parent.objectKind, child.objectKind)
                     self.rel_statistics[key] += 1
+                    if parent not in self.obj_statistics:
+                        self.obj_statistics[parent] = ObjectStatistics(
+                            {"key": parent_dict}
+                        )
                     self.obj_statistics[parent].add_child(child)
+                    if child not in self.obj_statistics:
+                        self.obj_statistics[child] = ObjectStatistics(
+                            {"key": child_dict}
+                        )
                     self.obj_statistics[child].add_parent(parent)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Adds a number of features to the Python library:
* If an AdapterDefinition is passed into a 'CollectResult', external object types
  are no longer returned in the result unless they contain content. Relationships
  are not affected. (Note: requires unreleased mp-test update)
* Adds 'RelationshipUpdateModes' enum to control how relationships are returned from 
  'CollectResult'
* Add 'get_object' and 'get_objects_by_type' helper methods in 'CollectResult'
* Add 'adapter_type()' and 'object_type()' helper methods in 'Object'
* Add 'has_content()' method in 'Object' that returns true if the object contains 
  at least one metric, property, or event

In addition
* Adds unit tests for CollectResult class
* Fixes a bug in mp-test that occurs when collect returns an object in the "relationships" dictionary that is not part of the "result" dictionary

Resolves: https://jira.eng.vmware.com/browse/VOPERATION-37456, https://jira.eng.vmware.com/browse/VOPERATION-37232

Note: Failing CI will be resolved after #70 is merged.