### PR TITLE
Story/headless build support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 VMware Aria Operations Integration SDK
 --------------------------------------
-## 0.5.0 (11-28-2022)
+## Unreleased
+* Adds several flags to mp-build for running on headless build servers:
+  * '--no-ttl': Remove UI flourishes and prompts that require a TTL.
+  * '--registry-tag': Specify the container registry to upload the built adapter container to without relying on the 'config.json' file.
+  * '--registry-username': Specify the registry username if docker is not logged in to the registry.
+  * '--registry-password': Specify the registry password if docker is not logged in to the registry.
+* Improve logging in adapter created from 'mp-init'.
+* Fixes issue that was preventing installation on Windows.
 * 'mp-test' asks for SuiteAPI credentials when setting up a new connection.
 * 'Long collection' tests now automatically detect several common issues.
 

--- a/vmware_aria_operations_integration_sdk/adapter_container.py
+++ b/vmware_aria_operations_integration_sdk/adapter_container.py
@@ -23,20 +23,17 @@ from vmware_aria_operations_integration_sdk.docker_wrapper import get_container_
 from vmware_aria_operations_integration_sdk.docker_wrapper import init
 from vmware_aria_operations_integration_sdk.docker_wrapper import run_image
 from vmware_aria_operations_integration_sdk.docker_wrapper import stop_container
-from vmware_aria_operations_integration_sdk.logging_format import CustomFormatter
-from vmware_aria_operations_integration_sdk.logging_format import PTKHandler
 from vmware_aria_operations_integration_sdk.ui import Spinner
 
 logger = logging.getLogger(__name__)
-logger.setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
-consoleHandler = PTKHandler()
-consoleHandler.setFormatter(CustomFormatter())
-logger.addHandler(consoleHandler)
 
 
 class AdapterContainer:
-    def __init__(self, path: str):
-        self.docker_client: DockerClient = init()
+    def __init__(self, path: str, docker_client: Optional[DockerClient] = None):
+        if not docker_client:
+            self.docker_client = init()
+        else:
+            self.docker_client = docker_client
         self.path: str = path
         self.memory_limit: Optional[int] = None
         self.started: bool = False

--- a/vmware_aria_operations_integration_sdk/mp_build.py
+++ b/vmware_aria_operations_integration_sdk/mp_build.py
@@ -10,6 +10,7 @@ import shutil
 import time
 import traceback
 import zipfile
+from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Tuple
@@ -111,7 +112,7 @@ def get_registry_components(docker_registry: str) -> Tuple[str, str]:
     return host, path
 
 
-def is_valid_registry(docker_registry: str, **kwargs) -> bool:
+def is_valid_registry(docker_registry: str, **kwargs: Any) -> bool:
     try:
         login(docker_registry, **kwargs)
     except LoginError:
@@ -140,7 +141,7 @@ def get_docker_registry(
     adapter_kind_key: str,
     config_file: str,
     docker_registry_arg: Optional[str],
-    **kwargs,
+    **kwargs: Any,
 ) -> str:
     docker_registry = get_config_value("docker_registry", config_file=config_file)
     default_registry_value = f"harbor-repo.vmware.com/vmware_aria_operations_integration_sdk_mps/{adapter_kind_key.lower()}"
@@ -181,7 +182,7 @@ def get_docker_registry(
             key="docker_registry", value=docker_registry, config_file=config_file
         )
 
-    return docker_registry
+    return str(docker_registry)
 
 
 def fix_describe(describe_adapter_kind_key: Optional[str], manifest_file: str) -> Dict:
@@ -209,8 +210,8 @@ async def build_pak_file(
     project_path: str,
     insecure_communication: bool,
     docker_registry_arg: Optional[str],
-    **kwargs,
-):
+    **kwargs: Any,
+) -> str:
     docker_client = init()
 
     manifest_file = os.path.join(project_path, "manifest.txt")
@@ -219,7 +220,7 @@ async def build_pak_file(
         manifest = json.load(manifest_fd)
 
     config_file = os.path.join(project_path, "config.json")
-    adapter_container = AdapterContainer(project_path)
+    adapter_container = AdapterContainer(project_path, docker_client)
     memory_limit = get_config_value(
         "default_memory_limit", 1024, os.path.join(project_path, "config.json")
     )

--- a/vmware_aria_operations_integration_sdk/mp_build.py
+++ b/vmware_aria_operations_integration_sdk/mp_build.py
@@ -17,6 +17,7 @@ from typing import Tuple
 
 import httpx
 
+from vmware_aria_operations_integration_sdk import ui
 from vmware_aria_operations_integration_sdk.adapter_container import AdapterContainer
 from vmware_aria_operations_integration_sdk.config import get_config_value
 from vmware_aria_operations_integration_sdk.config import set_config_value
@@ -428,12 +429,23 @@ def main() -> None:
             "must be configured to listen on port 8080.",
             action="store_true",
         )
+
+        parser.add_argument(
+            "--no-ttl",
+            help="If this flag is present, certain features dependent on having a TTL "
+            "will be disabled. All arguments will need to be passed as command "
+            "line options. This is useful for running mp-build on a headless "
+            "build server",
+            action="store_true",
+        )
         parsed_args = parser.parse_args()
         project = get_project(parsed_args)
         insecure_communication = parsed_args.insecure_collector_communication
         docker_registry = parsed_args.registry_tag
         registry_username = parsed_args.registry_username
         registry_password = parsed_args.registry_password
+        if parsed_args.no_ttl:
+            ui.TTL = False
 
         log_file_path = os.path.join(project.path, "logs")
         mkdir(log_file_path)


### PR DESCRIPTION
The previous headless support was not sufficient in some cases. This adds a "--no-ttl" flag to mp-build that disables spinners and other interactive UI components.

In addition, resolves a minor issue where two docker clients were created in mp-build, which was polluting the logs.