### PR TITLE
Do not include .gitkeep files in pak files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 VMware Aria Operations Integration SDK
 --------------------------------------
-## 0.5.0 (11-28-2022)
+## Unreleased
+* Do not include '.gitkeep' files in pak files.
 * 'mp-test' asks for SuiteAPI credentials when setting up a new connection.
 * 'Long collection' tests now automatically detect several common issues.
 

--- a/vmware_aria_operations_integration_sdk/filesystem.py
+++ b/vmware_aria_operations_integration_sdk/filesystem.py
@@ -39,12 +39,14 @@ def rmdir(basepath: str, *paths: str) -> None:
 
 
 def zip_file(_zip: zipfile.ZipFile, file: str) -> None:
+    if os.path.basename(file) == ".gitkeep":
+        return
     _zip.write(file, compress_type=zipfile.ZIP_DEFLATED)
 
 
 def zip_dir(_zip: zipfile.ZipFile, directory: str) -> None:
     for file in files_in_directory(directory):
-        _zip.write(file, compress_type=zipfile.ZIP_DEFLATED)
+        zip_file(_zip, file)
 
 
 def files_in_directory(directory: str) -> Generator[str, None, None]:


### PR DESCRIPTION
Ignores .gitkeep files when generating a management pack.

Resolves VOPERATION-38186

Before:
<img width="836" alt="image" src="https://user-images.githubusercontent.com/3310870/220722869-f86d5d9a-fd9c-40a0-b0b3-3a7c87034fb9.png">

After:
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/3310870/220723210-824334d7-53b0-4fb7-b4c0-2e79156dcb59.png">
