### PR TITLE
Adds an optional 'default_value' parameter to get_identifier()

### DIFF
--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -1,19 +1,20 @@
 VMware Aria Operations Integration SDK Library
 ----------------------------------------------
 ## Unreleased
+* Adds an optional 'default_value' parameter to the Object::get_identifier method.
 * Adds a 'Timer' class that automatically logs start and end times, and is able
   to generate an ascii chart of all times suitable for adapter logs.
 
 ## 0.6.0 (02-03-2023)
 * If an AdapterDefinition is passed into a 'CollectResult', external object types
   are no longer returned in the result unless they contain content. Relationships
-  are not affected. (Note: requires unreleased mp-test update)
+  are not affected. (Note: requires unreleased mp-test update).
 * Adds 'RelationshipUpdateModes' enum to control how relationships are returned from 
-  'CollectResult'
-* Add 'get_object' and 'get_objects_by_type' helper methods in 'CollectResult'
-* Add 'adapter_type()' and 'object_type()' helper methods in 'Object'
+  'CollectResult'.
+* Add 'get_object' and 'get_objects_by_type' helper methods in 'CollectResult'.
+* Add 'adapter_type()' and 'object_type()' helper methods in 'Object'.
 * Add 'has_content()' method in 'Object' that returns true if the object contains 
-  at least one metric, property, or event
+  at least one metric, property, or event.
 * Add 'collection_number' to Adapter Instance. Starts at 0 and increments each time 
   'collect' is called. Requires server based off of base-python-adapter 0.10.0 or 
   higher.
@@ -22,16 +23,16 @@ VMware Aria Operations Integration SDK Library
   Requires server based off of base-python-adapter 0.10.0 or higher.
 
 ## 0.5.0 (01-25-2023)
-* Add a 'adapter_logging' module simplify logging in adapters
+* Add a 'adapter_logging' module simplify logging in adapters.
 * Add python logging handler 'NullLogger' as the default logger, to suppress 
-  messages if the calling adapter has not set up logging
+  messages if the calling adapter has not set up logging.
 
 ## 0.4.7 (01-13-2023)
 * Fix a bug where the 'Authorization' header was set with an empty token when 
-  acquiring a suite-api token, which in some cases resulted in 401 errors
+  acquiring a suite-api token, which in some cases resulted in 401 errors.
 
 ## 0.4.6 (12-9-2022)
-* Fix a bug where default values for Events were not set correctly
+* Fix a bug where default values for Events were not set correctly.
 
 ## 0.4.5 (11-17-2022)
 * Add getters to Object class:
@@ -39,23 +40,23 @@ VMware Aria Operations Integration SDK Library
   - get_last_property_value
   - get_metric_values
   - get_last_metric_value
-* Fix issue where auto-generated attribute timestamps only update once per collection
+* Fix issue where auto-generated attribute timestamps only update once per collection.
 
 ## 0.4.4 (11-10-2022)
-* Fix edge case when default value of an Integer Identifier is set to '0'
-* Fix case where adding automatically adding 'Content-Type' header in post requests caused an exception
+* Fix edge case when default value of an Integer Identifier is set to '0'.
+* Fix case where adding automatically adding 'Content-Type' header in post requests caused an exception.
 
 ## 0.4.3 (11-03-2022)
-* Fix case where 'None' was being coerced to a string
-* Set 'dashboard_order' default value to '0' instead of 'None'
-* Remove 'dt_type' from Metrics/Properties, as it is no longer used by Aria Ops
+* Fix case where 'None' was being coerced to a string.
+* Set 'dashboard_order' default value to '0' instead of 'None'.
+* Remove 'dt_type' from Metrics/Properties, as it is no longer used by Aria Ops.
 
 ## 0.4.2 (11-02-2022)
-* Fix retrieval of SuiteAPI credentials
+* Fix retrieval of SuiteAPI credentials.
 
 ## 0.4.1 (11-02-2022)
-* Add paging to SuiteAPIClient
-* Rename VROpsSuiteApiClient to SuiteAPIClient
+* Add paging to SuiteAPIClient.
+* Rename VROpsSuiteApiClient to SuiteAPIClient.
 
 ## 0.4.0 (10-28-2022)
-* Initial release with installation via PyPI
+* Initial release with installation via PyPI.

--- a/lib/python/src/aria/ops/object.py
+++ b/lib/python/src/aria/ops/object.py
@@ -82,15 +82,23 @@ class Key:
     def __hash__(self) -> int:
         return hash(self.__key())
 
-    def get_identifier(self, key: str) -> Optional[str]:
+    def get_identifier(
+        self, key: str, default_value: Optional[str] = None
+    ) -> Optional[str]:
         """Return the value for the given identifier key
 
         :param key: The identifier key
-        :return: The value associated with the identifier, or 'None' if the identifier key does not exist
+        :param default_value: An optional default value
+        :return: The value associated with the identifier.
+        If the value associated with the identifier is empty and 'default_value' is
+        provided, returns 'default_value'.
+        If the identifier does not exist, returns default_value if provided, else 'None'.
         """
         if self.identifiers.get(key):
-            return self.identifiers[key].value
-        return None
+            if self.identifiers[key].value or default_value is None:
+                return self.identifiers[key].value
+            return default_value
+        return default_value
 
     def get_json(self) -> dict:
         """Get a JSON representation of this Key
@@ -224,13 +232,19 @@ class Object:
         """
         return self._key.object_kind
 
-    def get_identifier_value(self, identifier_key: str) -> Optional[str]:
+    def get_identifier_value(
+        self, identifier_key: str, default_value: Optional[str] = None
+    ) -> Optional[str]:
         """Retrieve the value of a given identifier
 
         :param identifier_key: Key of the identifier
-        :return: value associated with the identifier, or None if identifier does not exist
+        :param default_value: An optional default value
+        :return: The value associated with the identifier.
+        If the value associated with the identifier is empty and 'default_value' is
+        provided, returns 'default_value'.
+        If the identifier does not exist, returns default_value if provided, else 'None'.
         """
-        return self._key.get_identifier(identifier_key)
+        return self._key.get_identifier(identifier_key, default_value)
 
     def add_metric(self, metric: Metric) -> None:
         """Method that adds a single Metric data point to this Object

--- a/lib/python/tests/test_object_key.py
+++ b/lib/python/tests/test_object_key.py
@@ -1,0 +1,46 @@
+#  Copyright 2023 VMware, Inc.
+#  SPDX-License-Identifier: Apache-2.0
+from aria.ops.object import Identifier
+from aria.ops.object import Key
+
+
+def test_get_identifier() -> None:
+    identifier1 = Identifier("key1", "value1")
+    identifier2 = Identifier("key2", "value2")
+    key = Key("adapter_kind", "object_kind", "name", [identifier1, identifier2])
+    assert key.get_identifier("key1") == "value1"
+
+
+def test_get_identifier_with_default() -> None:
+    identifier1 = Identifier("key1", "value1")
+    identifier2 = Identifier("key2", "value2")
+    key = Key("adapter_kind", "object_kind", "name", [identifier1, identifier2])
+    assert key.get_identifier("key2", "default") == "value2"
+
+
+def test_get_not_existing_identifier() -> None:
+    identifier1 = Identifier("key1", "value1")
+    identifier2 = Identifier("key2", "value2")
+    key = Key("adapter_kind", "object_kind", "name", [identifier1, identifier2])
+    assert key.get_identifier("bad_key") is None
+
+
+def test_get_not_existing_identifier_with_default() -> None:
+    identifier1 = Identifier("key1", "value1")
+    identifier2 = Identifier("key2", "value2")
+    key = Key("adapter_kind", "object_kind", "name", [identifier1, identifier2])
+    assert key.get_identifier("bad_key", "default") == "default"
+
+
+def test_get_empty_identifier() -> None:
+    identifier1 = Identifier("key1", "")
+    identifier2 = Identifier("key2", "value2")
+    key = Key("adapter_kind", "object_kind", "name", [identifier1, identifier2])
+    assert key.get_identifier("key1") == ""
+
+
+def test_get_empty_identifier_with_default() -> None:
+    identifier1 = Identifier("key1", "")
+    identifier2 = Identifier("key2", "value2")
+    key = Key("adapter_kind", "object_kind", "name", [identifier1, identifier2])
+    assert key.get_identifier("key1", "default") == "default"


### PR DESCRIPTION
I was surprised this was missing.

Please think about if the behavior in each case makes sense (identifier not present vs identifier has Falsy value).