### PR TITLE
Bug/server issues

### DIFF
--- a/images/base-python-adapter/swagger_server/controllers/controller.py
+++ b/images/base-python-adapter/swagger_server/controllers/controller.py
@@ -24,8 +24,6 @@ logger = logging.getLogger(__name__)
 collection_number: int = 0
 last_collection_time: float = 0
 
-dir = tempfile.mkdtemp()
-
 
 def collect(body: Optional[AdapterConfig] = None) -> Tuple[str, int]:  # noqa: E501
     """Data Collection
@@ -162,6 +160,7 @@ def runcommand(
     extras: Optional[Dict] = None,
 ) -> Tuple[str, int]:
     logger.debug(f"Running command {repr(command)}")
+    dir = tempfile.mkdtemp()
     # These are named from the perspective of the subprocess. We write the subprocess input to the input pipe
     # and read the subprocess output from the output pipe.
     input_pipe = os.path.join(dir, "input_pipe")
@@ -180,8 +179,6 @@ def runcommand(
     )
 
     try:
-        safe_unlink(input_pipe)
-        safe_unlink(output_pipe)
         os.mkfifo(input_pipe)
         os.mkfifo(output_pipe)
         logger.debug("Finished making pipes")
@@ -265,6 +262,7 @@ def runcommand(
     finally:
         safe_unlink(input_pipe)
         safe_unlink(output_pipe)
+        os.rmdir(dir)
 
 
 def safe_unlink(file: str) -> None:

--- a/images/base-python-adapter/swagger_server/controllers/controller.py
+++ b/images/base-python-adapter/swagger_server/controllers/controller.py
@@ -206,9 +206,10 @@ def runcommand(
         if len(err.strip()) > 0:
             logger.warning(err)
 
-        # process.communicate() will wait until the subprocess has exited. If the subprocess has exited and
-        # writer_thread is still alive, then the input was not read. In that case we want the writer_thread to
-        # complete, and the easiest way to do that is to read the pipe. It's not required for the adapter info
+        # process.communicate() will wait until the subprocess has exited. If the
+        # subprocess has exited and writer_thread is still alive, then the input was
+        # not read. In that case we want the writer_thread to complete, and the easiest
+        # way to do that is to read the pipe. It's not required for the adapter info
         # to be read, so this is not (necessarily) an error.
         if writer_thread.is_alive():
             logger.info("Subprocess exited before reading input.")
@@ -216,30 +217,34 @@ def runcommand(
                 fifo.read()
             writer_thread.join()
 
-        # If the subprocess has exited and reader_thread is still alive, there are two things that might have happened:
-        # 1.the reader thread is still proessing.
-        # 2.the adapter didn't write any results/crashed.
-        # for case 1 we want to give the reader thread some extra time to complete.
-        # for case 2 we want the reader_thread to complete but return an error to the user.
+        # If the subprocess has exited and reader_thread is still alive, there are two
+        # things that might have happened:
+        # 1. The reader thread is still processing.
+        # 2. The adapter didn't write any results/crashed.
+        # For case 1 we want to wait for the reader thread to complete.
+        # For case 2 we need to write to the named pipe so the reader_thread can
+        # complete, but return an error to the user.
         if reader_thread.is_alive():
-            logger.warning("Reader thread is still open")
-            logger.debug("Sleeping for 5 seconds to allow reader thread to finish")
-            time.sleep(5)
+            logger.info("Reader thread is still running")
+            # Ensure that the reader thread is past it's blocking read:
+            try:
+                # Opening a named pipe using the 'NONBLOCK' flag means that it will
+                # immediately fail if there isn't a corresponding blocking 'read'
+                # operation currently using the pipe
+                with os.fdopen(
+                    os.open(output_pipe, os.O_WRONLY | os.O_NONBLOCK), mode="w"
+                ) as fd:
+                    fd.write("")
+            except Exception as e:
+                # In some cases the open will fail with an OSError. This is ok. It means
+                # that the above open wasn't required. Unfortunately, it is not the case
+                # that if we don't get here than the open _was_ required. So we can't
+                # use this to distinguish between cases (1) and (2).
+                pass
+            logger.debug("Resolved potentially blocking read on reader thread")
 
-        # If after 5 seconds the reader thread hasn't completed, then is very likely that we are in case 2
-        # https://github.com/vmware/vmware-aria-operations-integration-sdk/issues/79
-        if reader_thread.is_alive():
-            logger.error(
-                "Reader thread is still alive after 5 seconds sleep process completed"
-            )
-            logger.debug("Closing output pipe manually")
-            with open(output_pipe, "w") as fifo:
-                fifo.write("")
-
-            logger.debug("Closed output pipe manually")
+            # Wait for the reader thread to complete.
             reader_thread.join()
-            # If we got here, result[0] should be none; we will explicitly set it anyway
-            result[0] = None
 
         logging.debug(f"Result object value: {result[0]}")
 
@@ -298,7 +303,7 @@ def write_adapter_instance(
 
 
 def read_results(
-    output_pipe: str, result: List[Tuple[str, int]], good_response_code: int
+    output_pipe: str, result: List[Optional[Tuple[str, int]]], good_response_code: int
 ) -> None:
     try:
         with open(output_pipe, "r") as fifo:
@@ -306,4 +311,4 @@ def read_results(
             result[0] = json.load(fifo), good_response_code
     except Exception as e:
         logger.warning(f"Unknown server error when reading results: {e}")
-        result[0] = "Unknown server error", 500
+        result[0] = None


### PR DESCRIPTION
* In some cases, the named pipes could be left on the filesystem after a collection finished. This fixes the issue by catching exceptions that may occur when trying to delete the named pipe, and continuing on to attempt to delete the subsequent named pipe if the first delete cannot occur.

* Fixes the deadlock that could arise from the named pipe being opened for writing twice. Details in comments.

Resolves #79 

Test: Forces the collection to fail (exit without writing a result) every 5 collections, and adds a 10-second delay to the processing section of the read results thread every 3 collections. This is on the MP scale test writing ~100,000 objects. In addition, I ran this code (without the intentional exits/delays) over the weekend without incident.
```
Collection                           | Duration | Avg CPU %                       | Avg Memory Usage %             | Memory Limit | Network I/O             | Block I/O
-------------------------------------+----------+---------------------------------+--------------------------------+--------------+-------------------------+--------------
1 (failed)                           | 0.46 s   | 6.5 % (0.0% / 0.0% / 23.4%)     | 2.0 % (2.0% / 2.0% / 2.0%)     | 2.0 GiB      | 3.31 KiB / 6.61 KiB     | 0.0 B / 0.0 B
2                                    | 23.31 s  | 80.9 % (0.0% / 100.0% / 113.6%) | 24.1 % (5.9% / 24.1% / 46.2%)  | 2.0 GiB      | 56.09 KiB / 114.14 MiB  | 0.0 B / 0.0 B
3 (longer than collection interval)  | 33.60 s  | 57.1 % (0.0% / 52.9% / 116.5%)  | 28.1 % (9.1% / 27.0% / 57.3%)  | 2.0 GiB      | 107.92 KiB / 228.23 MiB | 0.0 B / 0.0 B
4                                    | 21.99 s  | 86.5 % (0.0% / 100.1% / 115.9%) | 31.4 % (13.6% / 33.2% / 58.5%) | 2.0 GiB      | 160.38 KiB / 342.37 MiB | 0.0 B / 0.0 B
5                                    | 22.15 s  | 79.7 % (0.0% / 100.0% / 113.3%) | 33.8 % (17.9% / 35.6% / 59.2%) | 2.0 GiB      | 212.94 KiB / 456.52 MiB | 0.0 B / 0.0 B
6 (failed)                           | 0.47 s   | 22.2 %                          | 16.5 %                         | 2.0 GiB      | 214.09 KiB / 456.52 MiB | 0.0 B / 0.0 B
7                                    | 23.55 s  | 79.5 % (0.0% / 100.1% / 116.0%) | 37.9 % (20.7% / 36.7% / 64.2%) | 2.0 GiB      | 263.53 KiB / 570.65 MiB | 0.0 B / 0.0 B
8                                    | 22.16 s  | 79.9 % (0.0% / 100.1% / 111.7%) | 38.9 % (21.6% / 39.7% / 68.0%) | 2.0 GiB      | 314.18 KiB / 684.79 MiB | 0.0 B / 0.0 B
9 (longer than collection interval)  | 31.93 s  | 59.9 % (0.0% / 84.9% / 117.6%)  | 37.4 % (21.7% / 38.0% / 64.2%) | 2.0 GiB      | 365.03 KiB / 798.93 MiB | 0.0 B / 0.0 B
10                                   | 22.86 s  | 78.5 % (0.0% / 100.1% / 114.2%) | 40.8 % (21.8% / 41.3% / 73.1%) | 2.0 GiB      | 415.69 KiB / 913.07 MiB | 0.0 B / 0.0 B
11 (failed)                          | 0.45 s   | 21.1 %                          | 18.3 %                         | 2.0 GiB      | 416.84 KiB / 913.07 MiB | 0.0 B / 0.0 B
12 (longer than collection interval) | 34.30 s  | 57.0 % (0.0% / 66.0% / 116.8%)  | 38.4 % (21.8% / 38.1% / 63.4%) | 2.0 GiB      | 468.76 KiB / 1.0 GiB    | 0.0 B / 0.0 B
13                                   | 22.97 s  | 80.1 % (0.0% / 100.0% / 113.4%) | 38.1 % (21.0% / 40.2% / 63.8%) | 2.0 GiB      | 519.54 KiB / 1.11 GiB   | 0.0 B / 0.0 B
14                                   | 22.92 s  | 82.8 % (0.0% / 100.2% / 116.0%) | 39.8 % (21.9% / 41.2% / 70.7%) | 2.0 GiB      | 569.16 KiB / 1.23 GiB   | 0.0 B / 0.0 B
15 (longer than collection interval) | 33.27 s  | 61.0 % (0.0% / 81.0% / 115.4%)  | 39.0 % (21.8% / 38.2% / 67.9%) | 2.0 GiB      | 619.43 KiB / 1.34 GiB   | 0.0 B / 0.0 B
16 (failed)                          | 0.42 s   | 20.0 %                          | 18.5 %                         | 2.0 GiB      | 620.58 KiB / 1.34 GiB   | 0.0 B / 0.0 B
17                                   | 22.04 s  | 85.9 % (0.0% / 100.2% / 112.6%) | 39.3 % (22.1% / 41.0% / 63.3%) | 2.0 GiB      | 672.67 KiB / 1.45 GiB   | 0.0 B / 0.0 B
18 (longer than collection interval) | 33.54 s  | 58.9 % (0.0% / 71.3% / 115.1%)  | 40.1 % (22.1% / 38.2% / 67.2%) | 2.0 GiB      | 723.65 KiB / 1.56 GiB   | 0.0 B / 0.0 B
19                                   | 23.25 s  | 81.0 % (0.0% / 100.0% / 115.3%) | 40.4 % (22.1% / 41.2% / 69.2%) | 2.0 GiB      | 773.85 KiB / 1.67 GiB   | 0.0 B / 0.0 B
20                                   | 23.04 s  | 78.1 % (0.0% / 99.9% / 114.6%)  | 40.5 % (22.0% / 41.8% / 71.5%) | 2.0 GiB      | 821.8 KiB / 1.78 GiB    | 0.0 B / 0.0 B
```