### PR TITLE
Adds a version flag to each of the tools

### DIFF
--- a/vmware_aria_operations_integration_sdk/mp_build.py
+++ b/vmware_aria_operations_integration_sdk/mp_build.py
@@ -16,6 +16,7 @@ from typing import Optional
 from typing import Tuple
 
 import httpx
+import pkg_resources
 
 from vmware_aria_operations_integration_sdk import ui
 from vmware_aria_operations_integration_sdk.adapter_container import AdapterContainer
@@ -398,6 +399,15 @@ def main() -> None:
         description = "Tool for building a pak file for a project."
         parser = argparse.ArgumentParser(description=description)
 
+        parser.add_argument(
+            "-V",
+            "--version",
+            action="version",
+            version=pkg_resources.get_distribution(
+                "vmware-aria-operations-integration-sdk"
+            ).version,
+        )
+
         # General options
         parser.add_argument(
             "-p",
@@ -529,7 +539,8 @@ def main() -> None:
         logger.info("Build cancelled")
         exit(1)
     except SystemExit as system_exit:
-        logger.error("Unable to build pak file")
+        if system_exit.code != 0:
+            logger.error("Unable to build pak file")
         exit(system_exit.code)
     except Exception as exception:
         logger.error("Unexpected exception occurred while trying to build pak file")

--- a/vmware_aria_operations_integration_sdk/mp_init.py
+++ b/vmware_aria_operations_integration_sdk/mp_init.py
@@ -1,5 +1,6 @@
 #  Copyright 2022 VMware, Inc.
 #  SPDX-License-Identifier: Apache-2.0
+import argparse
 import json
 import logging
 import os
@@ -225,6 +226,18 @@ def create_project(
 
 
 def main() -> None:
+    description = "Tool for creating a new Management Pack for VMware Aria Operations."
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=pkg_resources.get_distribution(
+            "vmware-aria-operations-integration-sdk"
+        ).version,
+    )
+    parser.parse_args()
+
     path = ""
     try:
         path = path_prompt(

--- a/vmware_aria_operations_integration_sdk/mp_test.py
+++ b/vmware_aria_operations_integration_sdk/mp_test.py
@@ -15,6 +15,7 @@ from xml.etree.ElementTree import Element
 
 import httpx
 import lxml.etree as ET
+import pkg_resources
 import urllib3
 from docker.errors import APIError
 from docker.errors import ContainerError
@@ -642,6 +643,15 @@ def input_parameter(parameter_type: str, parameter: Element, resources: Dict) ->
 def main() -> None:
     description = "Tool for running adapter test and collect methods outside of a VMware Aria Operations Cloud Proxy."
     parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=pkg_resources.get_distribution(
+            "vmware-aria-operations-integration-sdk"
+        ).version,
+    )
 
     # General options
     parser.add_argument(


### PR DESCRIPTION
I've wanted this for a while, decided it was simple enough to just do it.

Adds `-V` and `--version` flags to each of `mp-init`, `mp-test`, and `mp-build`.

<img width="840" alt="image" src="https://user-images.githubusercontent.com/3310870/228038052-760dc832-8948-4bad-8176-aa6ef87031a2.png">
