### PR TITLE
Updates to server section of loglevels.cfg no longer requires a restart to take effect

### DIFF
--- a/images/base-python-adapter/swagger_server/controllers/controller.py
+++ b/images/base-python-adapter/swagger_server/controllers/controller.py
@@ -18,6 +18,7 @@ from swagger_server.models import ApiVersion
 from swagger_server.models.adapter_config import AdapterConfig  # noqa: E501
 from swagger_server.models.collect_result import CollectResult  # noqa: E501
 from swagger_server.models.test_result import TestResult  # noqa: E501
+from swagger_server.server_logging import update_log_levels
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ def collect(body: Optional[AdapterConfig] = None) -> Tuple[str, int]:  # noqa: E
 
     :rtype: CollectResult
     """
+    update_log_levels()
     logger.info("Request: collect")
 
     if connexion.request.is_json:
@@ -71,6 +73,7 @@ def definition() -> Tuple[str, int]:
 
     :rtype: AdapterDefinition
     """
+    update_log_levels()
     logger.info("Request: definition")
 
     command = getcommand("adapter_definition")
@@ -93,6 +96,7 @@ def test(body: Optional[AdapterConfig] = None) -> Tuple[str, int]:  # noqa: E501
 
     :rtype: TestResult
     """
+    update_log_levels()
     logger.info("Request: test")
 
     if connexion.request.is_json:
@@ -114,6 +118,7 @@ def api_version() -> ApiVersion:  # noqa: E501
 
     :rtype: str
     """
+    update_log_levels()
     logger.info("Request: apiVersion")
     # This should match the version in swagger_server/swagger/swagger.yaml#/info/version
     return ApiVersion(major=1, minor=0, maintenance=0)
@@ -131,6 +136,7 @@ def get_endpoint_urls(
 
     :rtype: List[str]
     """
+    update_log_levels()
     logger.info("Request: endpointURLs")
 
     if connexion.request.is_json:

--- a/images/base-python-adapter/swagger_server/server_logging.py
+++ b/images/base-python-adapter/swagger_server/server_logging.py
@@ -31,7 +31,7 @@ def setup_logging(
             level=_get_default_log_level(),
             handlers=[log_handler],
         )
-        _set_log_levels()
+        update_log_levels()
     except Exception:
         logging.basicConfig(level=logging.CRITICAL + 1)
 
@@ -62,12 +62,23 @@ def _get_default_log_level(default_level: int = logging.INFO) -> int:
         return default_level
 
 
-def _set_log_levels() -> None:
+def update_log_levels() -> None:
+    default_log_level = _get_default_log_level()
+
+    # Set the root logger level
+    logging.getLogger().setLevel(default_log_level)
+
+    # Reset all existing non-root loggers to the default level (the loggingDict does
+    # not include the root logger)
+    for logger_name in logging.root.manager.loggerDict:
+        logging.getLogger(logger_name).setLevel(default_log_level)
+
+    # Set each logger in the config file to the level specified
     log_config_file = os.path.join(os.sep, "var", "log", "loglevels.cfg")
     config = ConfigParser()
     config.read(log_config_file)
-    for logger in config["server"]:
-        logging.getLogger(logger).setLevel(config["server"][logger])
+    for logger_name in config["server"]:
+        logging.getLogger(logger_name).setLevel(config["server"][logger_name])
 
 
 def getLogger(name: str) -> logging.Logger:


### PR DESCRIPTION
Updates to server section of loglevels.cfg no longer requires a restart to take effect

I was sure we had a ticket for this, but I don't see it in Jira or Github.


Long run log which starts at INFO level and then switches to DEBUG after 3 collections:
```
2023-03-27 22:27:29,118 main INFO Port: 8080
2023-03-27 22:27:29,286 swagger_server.controllers.controller INFO Request: apiVersion
2023-03-27 22:27:30,414 swagger_server.controllers.controller INFO Request: definition
2023-03-27 22:27:31,87 swagger_server.controllers.controller INFO Subprocess exited before reading input.
2023-03-27 22:27:31,119 swagger_server.controllers.controller INFO Request: collect
2023-03-27 22:28:06,185 swagger_server.controllers.controller INFO Request: collect
2023-03-27 22:28:39,899 swagger_server.controllers.controller INFO Request: collect
2023-03-27 22:28:41,662 root DEBUG Result object value: ({'result': [{'key': {'name': 'CPU', 'adapterKind': 'Testserver', 'objectKind': 'CPU', 'identifiers': []}, 'metrics': [{'key': 'user_time', 'numberValue': 401.6, 'timestamp': 1679956121595}, {'key': 'nice_time', 'numberValue': 0.0, 'timestamp': 1679956121595}, {'key': 'system_time', 'numberValue': 319.52, 'timestamp': 1679956121595}, {'key': 'idle_time', 'numberValue': 275650.68, 'timestamp': 1679956121595}], 'properties': [{'key': 'cpu_count', 'numberValue': 8.0, 'timestamp': 1679956120594}], 'events': []}, {'key': {'name': 'Disk', 'adapterKind': 'Testserver', 'objectKind': 'Disk', 'identifiers': []}, 'metrics': [{'key': 'total_space', 'numberValue': 62671097856.0, 'timestamp': 1679956121595}, {'key': 'used_space', 'numberValue': 7711633408.0, 'timestamp': 1679956121595}, {'key': 'free_space', 'numberValue': 51742748672.0, 'timestamp': 1679956121595}, {'key': 'percent_used_space', 'numberValue': 13.0, 'timestamp': 1679956121595}], 'properties': [{'key': 'partition', 'stringValue': '/dev/vda1', 'timestamp': 1679956121595}], 'events': []}, {'key': {'name': 'System', 'adapterKind': 'Testserver', 'objectKind': 'System', 'identifiers': []}, 'metrics': [], 'properties': [], 'events': []}], 'relationships': [], 'nonExistingObjects': []}, 200)
2023-03-27 22:28:41,664 connexion.apis.abstract DEBUG Getting data and status code
2023-03-27 22:28:41,666 connexion.apis.abstract DEBUG Prepared body and status code (200)
2023-03-27 22:28:41,668 connexion.apis.abstract DEBUG Got framework response
2023-03-27 22:29:13,466 connexion.apis.flask_api DEBUG Getting data and status code
2023-03-27 22:29:13,468 connexion.decorators.validation DEBUG http://localhost:8080/collect validating schema...
2023-03-27 22:29:13,470 connexion.decorators.parameter DEBUG Function Arguments: ['body']
2023-03-27 22:29:13,476 swagger_server.controllers.controller INFO Request: collect
2023-03-27 22:29:14,957 root DEBUG Result object value: ({'result': [{'key': {'name': 'CPU', 'adapterKind': 'Testserver', 'objectKind': 'CPU', 'identifiers': []}, 'metrics': [{'key': 'user_time', 'numberValue': 402.15, 'timestamp': 1679956154917}, {'key': 'nice_time', 'numberValue': 0.0, 'timestamp': 1679956154917}, {'key': 'system_time', 'numberValue': 319.68, 'timestamp': 1679956154917}, {'key': 'idle_time', 'numberValue': 275916.24, 'timestamp': 1679956154917}], 'properties': [{'key': 'cpu_count', 'numberValue': 8.0, 'timestamp': 1679956153915}], 'events': []}, {'key': {'name': 'Disk', 'adapterKind': 'Testserver', 'objectKind': 'Disk', 'identifiers': []}, 'metrics': [{'key': 'total_space', 'numberValue': 62671097856.0, 'timestamp': 1679956154918}, {'key': 'used_space', 'numberValue': 7711633408.0, 'timestamp': 1679956154918}, {'key': 'free_space', 'numberValue': 51742748672.0, 'timestamp': 1679956154918}, {'key': 'percent_used_space', 'numberValue': 13.0, 'timestamp': 1679956154918}], 'properties': [{'key': 'partition', 'stringValue': '/dev/vda1', 'timestamp': 1679956154918}], 'events': []}, {'key': {'name': 'System', 'adapterKind': 'Testserver', 'objectKind': 'System', 'identifiers': []}, 'metrics': [], 'properties': [], 'events': []}], 'relationships': [], 'nonExistingObjects': []}, 200)
2023-03-27 22:29:14,959 connexion.apis.abstract DEBUG Getting data and status code
2023-03-27 22:29:14,960 connexion.apis.abstract DEBUG Prepared body and status code (200)
2023-03-27 22:29:14,961 connexion.apis.abstract DEBUG Got framework response
2023-03-27 22:29:47,248 connexion.apis.flask_api DEBUG Getting data and status code
2023-03-27 22:29:47,249 connexion.decorators.validation DEBUG http://localhost:8080/collect validating schema...
2023-03-27 22:29:47,250 connexion.decorators.parameter DEBUG Function Arguments: ['body']
2023-03-27 22:29:47,255 swagger_server.controllers.controller INFO Request: collect
2023-03-27 22:29:47,256 swagger_server.controllers.controller DEBUG Command: /usr/local/bin/python app/adapter.py collect
2023-03-27 22:29:47,257 swagger_server.controllers.controller DEBUG Running command ['/usr/local/bin/python', 'app/adapter.py', 'collect']
2023-03-27 22:29:47,258 swagger_server.controllers.controller DEBUG Finished making pipes
2023-03-27 22:29:47,260 swagger_server.controllers.controller DEBUG Started process ['/usr/local/bin/python', 'app/adapter.py', 'collect', '/tmp/tmpo80hp1hu/input_pipe', '/tmp/tmpo80hp1hu/output_pipe']
2023-03-27 22:29:47,692 swagger_server.controllers.controller DEBUG Opened input pipe for writing
2023-03-27 22:29:47,693 swagger_server.controllers.controller DEBUG Wrote adapter instance to input pipe /tmp/tmpo80hp1hu/input_pipe:
2023-03-27 22:29:47,694 swagger_server.controllers.controller DEBUG {
   "adapter_key": {
      "name": "Default",
      "adapter_kind": "Testserver",
      "object_kind": "Testserver_adapter_instance",
      "identifiers": [
         {
            "key": "ID",
            "value": "test",
            "is_part_of_uniqueness": true
         }
      ]
   },
   "credential_config": "REDACTED",
   "cluster_connection_info": "REDACTED",
   "certificate_config": {
      "certificates": []
   },
   "collection_number": 4,
   "collection_window": {
      "start_time": 1679956153477.8662,
      "end_time": 1679956187257.6025
   }
}
2023-03-27 22:29:48,706 swagger_server.controllers.controller DEBUG Opened output pipe <_io.TextIOWrapper name='/tmp/tmpo80hp1hu/output_pipe' mode='r' encoding='UTF-8'> for reading
2023-03-27 22:29:48,736 swagger_server.controllers.controller DEBUG
2023-03-27 22:29:48,738 root DEBUG Result object value: ({'result': [{'key': {'name': 'CPU', 'adapterKind': 'Testserver', 'objectKind': 'CPU', 'identifiers': []}, 'metrics': [{'key': 'user_time', 'numberValue': 402.69, 'timestamp': 1679956188698}, {'key': 'nice_time', 'numberValue': 0.0, 'timestamp': 1679956188698}, {'key': 'system_time', 'numberValue': 319.83, 'timestamp': 1679956188698}, {'key': 'idle_time', 'numberValue': 276185.51, 'timestamp': 1679956188698}], 'properties': [{'key': 'cpu_count', 'numberValue': 8.0, 'timestamp': 1679956187694}], 'events': []}, {'key': {'name': 'Disk', 'adapterKind': 'Testserver', 'objectKind': 'Disk', 'identifiers': []}, 'metrics': [{'key': 'total_space', 'numberValue': 62671097856.0, 'timestamp': 1679956188698}, {'key': 'used_space', 'numberValue': 7711633408.0, 'timestamp': 1679956188698}, {'key': 'free_space', 'numberValue': 51742748672.0, 'timestamp': 1679956188698}, {'key': 'percent_used_space', 'numberValue': 13.0, 'timestamp': 1679956188698}], 'properties': [{'key': 'partition', 'stringValue': '/dev/vda1', 'timestamp': 1679956188698}], 'events': []}, {'key': {'name': 'System', 'adapterKind': 'Testserver', 'objectKind': 'System', 'identifiers': []}, 'metrics': [], 'properties': [], 'events': []}], 'relationships': [], 'nonExistingObjects': []}, 200)
2023-03-27 22:29:48,739 connexion.apis.abstract DEBUG Getting data and status code
2023-03-27 22:29:48,740 connexion.apis.abstract DEBUG Prepared body and status code (200)
2023-03-27 22:29:48,741 connexion.apis.abstract DEBUG Got framework response
```