### PR TITLE
Add explanation of cell format to statistics output

### DIFF
--- a/vmware_aria_operations_integration_sdk/collection_statistics.py
+++ b/vmware_aria_operations_integration_sdk/collection_statistics.py
@@ -377,6 +377,7 @@ class LongCollectionStatistics:
 
         summary = (
             "Long Collection summary:\n\n"
+            + "Table cell format is: 'total (min/median/max)'\n\n"
             + obj_table
             + "\n"
             + growth_table
@@ -476,4 +477,10 @@ class CollectionStatistics:
             data.append([parent_object_type, child_object_type, count])
         rel_table = str(Table(headers, data))
 
-        return "Collection summary: \n\n" + obj_table + "\n" + rel_table
+        return (
+            "Collection summary: \n\n"
+            + "Table cell format is: 'total (min/median/max)'\n\n"
+            + obj_table
+            + "\n"
+            + rel_table
+        )


### PR DESCRIPTION
I'm open to suggestions on the text and placement, but this seemed logical enough to me.

Resolves VOPERATION-35023


Single collection:
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/3310870/228086661-b1670ee7-6838-447e-b556-4983da2e73d2.png">


Long run:
<img width="1535" alt="image" src="https://user-images.githubusercontent.com/3310870/228086504-02181542-364f-4231-ad8a-a3463955156c.png">
