### PR TITLE
Create and use a custom context for docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 VMware Aria Operations Integration SDK
 --------------------------------------
 ## Unreleased
+* Improves container image build times.
 * Do not include '.gitkeep' files in pak files.
 * Adds several flags to mp-build for running on headless build servers:
   * '--no-ttl': Remove UI flourishes and prompts that require a TTL.

--- a/vmware_aria_operations_integration_sdk/docker_wrapper.py
+++ b/vmware_aria_operations_integration_sdk/docker_wrapper.py
@@ -180,7 +180,7 @@ def _get_docker_context(directory: str) -> io.BytesIO:
 
 
 def _docker_context_inclusion_func(file: str) -> bool:
-    excludes = ["build", "conf", "content", "logs", "resources"]
+    excludes = ["build", "content", "logs", "resources"]
     if os.path.dirname(file) == "." and os.path.basename(file) in excludes:
         logger.debug(f"Skipping directory '{file}': Excluded by SDK")
         return False

--- a/vmware_aria_operations_integration_sdk/filesystem.py
+++ b/vmware_aria_operations_integration_sdk/filesystem.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import zipfile
+from typing import Callable
 from typing import Generator
 
 from vmware_aria_operations_integration_sdk.logging_format import CustomFormatter
@@ -49,8 +50,14 @@ def zip_dir(_zip: zipfile.ZipFile, directory: str) -> None:
         zip_file(_zip, file)
 
 
-def files_in_directory(directory: str) -> Generator[str, None, None]:
-    for root, directories, files in os.walk(directory):
+def files_in_directory(
+    directory: str, dir_inclusion_func: Callable[[str], bool] = lambda file: True
+) -> Generator[str, None, None]:
+    for root, directories, files in os.walk(directory, topdown=True):
+        directories[:] = [
+            d for d in directories if dir_inclusion_func(os.path.join(root, d))
+        ]
         yield root
         for filename in files:
-            yield os.path.join(root, filename)
+            f = os.path.join(root, filename)
+            yield f


### PR DESCRIPTION
Creates a custom context to pass to the docker build image command. The custom context excludes any directory that:
  * Is an top-level SDK-created directory that should not be used by the Dockerfile: `build`, ~`conf`~, `content`, `logs`, `resources`
  * Is hidden (e.g., .`git`, `.idea`, etc)
  * Contains a Python virtual environment

Example of running a 2-minute long-run. Times above the 2-minute mark is the time spent setting up the test, the majority of which is building the image.

Without custom context:
```
(venv-test) ❯ du -h -d 0
159M	.
(venv-test) ❯ time mp-test -c Default long-run -d 2m -i 30s
[...]
mp-test -c Default long-run -d 2m -i 30s  14.45s user 1.76s system 11% cpu 2:24.61 total
```

With custom context (Approximately 4MB):
```
(venv-test) ❯ time mp-test -c Default long-run -d 2m -I 30s
[...]
mp-test -c Default long-run -d 2m -i 30s  2.88s user 0.93s system 3% cpu 2:04.67 total
```

Resolves #89 
