### PR TITLE
Do not include empty content/resources directory in pak file

### DIFF
--- a/vmware_aria_operations_integration_sdk/filesystem.py
+++ b/vmware_aria_operations_integration_sdk/filesystem.py
@@ -45,19 +45,24 @@ def zip_file(_zip: zipfile.ZipFile, file: str) -> None:
     _zip.write(file, compress_type=zipfile.ZIP_DEFLATED)
 
 
-def zip_dir(_zip: zipfile.ZipFile, directory: str) -> None:
-    for file in files_in_directory(directory):
+def zip_dir(
+    _zip: zipfile.ZipFile, directory: str, include_empty_dirs: bool = True
+) -> None:
+    for file in files_in_directory(directory, include_empty_dirs=include_empty_dirs):
         zip_file(_zip, file)
 
 
 def files_in_directory(
-    directory: str, dir_inclusion_func: Callable[[str], bool] = lambda file: True
+    directory: str,
+    dir_inclusion_func: Callable[[str], bool] = lambda file: True,
+    include_empty_dirs: bool = True,
 ) -> Generator[str, None, None]:
     for root, directories, files in os.walk(directory, topdown=True):
         directories[:] = [
             d for d in directories if dir_inclusion_func(os.path.join(root, d))
         ]
-        yield root
-        for filename in files:
-            f = os.path.join(root, filename)
-            yield f
+        if files or directories or include_empty_dirs:
+            yield root
+            for filename in files:
+                f = os.path.join(root, filename)
+                yield f

--- a/vmware_aria_operations_integration_sdk/mp_build.py
+++ b/vmware_aria_operations_integration_sdk/mp_build.py
@@ -389,7 +389,7 @@ async def build_pak_file(
                     zip_file(pak, eula_file)
 
                 zip_dir(pak, "resources")
-                zip_dir(pak, "content")
+                zip_dir(pak, "content", include_empty_dirs=False)
                 zip_file(pak, "adapter.zip")
 
                 rm("adapter.zip")


### PR DESCRIPTION
Exclude any empty subdirectories in the `content` directory. This is a mitigation for the bug in Aria Ops 8.10.0-8.10.2 where an empty content/resources directory would cause all other content in the content directory to fail to import.

Resolves: #88 

Pak file contents before:
```
manifest.txt
eula.txt
resources/
resources/resources.properties
content/
content/supermetrics/
content/traversalspecs/
content/resources/
content/customgroups/
content/policies/
content/recommendations/
content/symptomdefs/
content/dashboards/
content/dashboards/testdashboard.json
content/files/
content/files/reskndmetric/
content/files/solutionconfig/
content/files/topowidget/
content/files/txtwidget/
content/alertdefs/
content/reports/
adapter.zip
```

Pak file contents after:
```
manifest.txt
eula.txt
resources/
resources/resources.properties
content/
content/dashboards/
content/dashboards/testdashboard.json
content/files/
adapter.zip
```