### PR TITLE
Ensure timeouts are set when method is set interactively

### DIFF
--- a/vmware_aria_operations_integration_sdk/mp_test.py
+++ b/vmware_aria_operations_integration_sdk/mp_test.py
@@ -161,13 +161,15 @@ async def run_long_collect(
 
 
 async def run_collect(
-    timeout: float,
+    timeout: Optional[float],
     project: Project,
     connection: Connection,
     adapter_container: AdapterContainer,
     title: str = "Running Collect",
     **kwargs: Any,
 ) -> CollectionBundle:
+    if timeout is None:
+        timeout = TimeValidator.get_sec("Collection Timeout", "5m")
     await adapter_container.wait_for_container_startup()
     with Spinner(title):
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -181,13 +183,15 @@ async def run_collect(
 
 
 async def run_connect(
-    timeout: float,
+    timeout: Optional[float],
     project: Project,
     connection: Connection,
     adapter_container: AdapterContainer,
     title: str = "Running Connect",
     **kwargs: Any,
 ) -> ConnectBundle:
+    if timeout is None:
+        timeout = TimeValidator.get_sec("Connection Timeout", "30s")
     await adapter_container.wait_for_container_startup()
     with Spinner(title):
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -201,13 +205,15 @@ async def run_connect(
 
 
 async def run_get_endpoint_urls(
-    timeout: float,
+    timeout: Optional[float],
     project: Project,
     connection: Connection,
     adapter_container: AdapterContainer,
     title: str = "Running Endpoint URLs",
     **kwargs: Any,
 ) -> EndpointURLsBundle:
+    if timeout is None:
+        timeout = TimeValidator.get_sec("Connection Timeout", "30s")
     await adapter_container.wait_for_container_startup()
     with Spinner(title):
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -221,13 +227,15 @@ async def run_get_endpoint_urls(
 
 
 async def run_get_adapter_definition(
-    timeout: float,
+    timeout: Optional[float],
     project: Project,
     connection: Connection,
     adapter_container: AdapterContainer,
     title: str = "Running Adapter Definition",
     **kwargs: Any,
 ) -> AdapterDefinitionBundle:
+    if timeout is None:
+        timeout = TimeValidator.get_sec("Connection Timeout", "30s")
     await adapter_container.wait_for_container_startup()
     with Spinner(title):
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -241,11 +249,13 @@ async def run_get_adapter_definition(
 
 
 async def run_get_server_version(
-    timeout: float,
+    timeout: Optional[float],
     adapter_container: AdapterContainer,
     title: str = "Running Get API " "Version",
     **kwargs: Any,
 ) -> VersionBundle:
+    if timeout is None:
+        timeout = TimeValidator.get_sec("Connection Timeout", "30s")
     await adapter_container.wait_for_container_startup()
     with Spinner(title):
         async with httpx.AsyncClient(timeout=timeout) as client:


### PR DESCRIPTION
When running `mp-test`, if a method (`collect`, `connect`, etc) was not selected using a command line argument and instead set interactively, the REST request to the adapter would not have a timeout set and could potentially hang forever. This ensures that the default timeout will always be set. 

After introducing a `time.sleep(60)` in the test connection method, we can select the method interactively and the request correctly times out:
```
 ❯ mp-test -c Default
Choose a method to test: Test Connection
Building adapter [Finished]
Waiting for adapter to start [Finished]
Running Connect [Finished]
Failed: 408 Request Timeout


Avg CPU %                   | Avg Memory Usage %         | Memory Limit | Network I/O         | Block I/O
----------------------------+----------------------------+--------------+---------------------+--------------
2.8 % (0.0% / 0.0% / 44.9%) | 5.9 % (4.0% / 6.2% / 6.2%) | 1.0 GiB      | 3.41 KiB / 6.69 KiB | 0.0 B / 0.0 B

Request completed in 30.00 seconds.

Unable to validate the response json. The 'http://localhost:8080/test' endpoint response was:
 408 Request Timeout

All validation logs written to '/Users/kylerokos/Code/server-development-mp/logs/validation.log'
```