### PR TITLE
Improve test result visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 VMware Aria Operations Integration SDK
 --------------------------------------
 ## Unreleased
+* Improves visibility of failed test connections.
+* Adds record of successfull validation tests to 'validation.log'
 * Improves container image build times.
 * Fixes an issue that in certain scenarios would result in a pak file failing to install.
 * Implements log rotation for 'test.log' and 'build.log' files.

--- a/tests/validation/test_highlights.py
+++ b/tests/validation/test_highlights.py
@@ -129,7 +129,7 @@ class TestHighlights:
             normal_collection.add(collection_bundle)
 
         highlight = normal_collection.validate()
-        assert len(highlight.messages) == 0
+        assert highlight.issue_count() == 0
 
     def test_highlight_for_growing_unique_objects(self):
         response = TestObject()
@@ -288,7 +288,7 @@ class TestHighlights:
         highlight = highlight_metric_growth(
             changing_metric_value_per_collection.long_collection_statistics
         )
-        assert len(highlight.messages) == 0
+        assert highlight.issue_count() == 0
 
     def test_property_highlight(self):
         response = TestObject()
@@ -338,7 +338,7 @@ class TestHighlights:
         highlight = highlight_property_growth(
             stable_collection.long_collection_statistics
         )
-        assert len(highlight.messages) == 0
+        assert highlight.issue_count() == 0
 
     def test_property_value_highlight(self):
         response = TestObject()
@@ -388,7 +388,7 @@ class TestHighlights:
         highlight = highlight_property_value_growth(
             changing_metric_value_per_collection.long_collection_statistics
         )
-        assert len(highlight.messages) == 0
+        assert highlight.issue_count() == 0
 
     def test_event_highlight(self):
         response = TestObject()
@@ -446,4 +446,4 @@ class TestHighlights:
         highlight = highlight_event_growth(
             changing_metric_value_per_collection.long_collection_statistics
         )
-        assert len(highlight.messages) == 0
+        assert highlight.issue_count() == 0

--- a/vmware_aria_operations_integration_sdk/serialization.py
+++ b/vmware_aria_operations_integration_sdk/serialization.py
@@ -215,6 +215,12 @@ class ConnectBundle(ResponseBundle):
             request, response, duration, container_statistics, [validate_api_response]
         )
 
+    def validate(self, project: Project) -> Result:
+        result = super().validate(project)
+        if self.failed():
+            result.with_error(f"Connect attempt failed: {self.get_failure_message()}")
+        return result
+
 
 class EndpointURLsBundle(ResponseBundle):
     def __init__(

--- a/vmware_aria_operations_integration_sdk/serialization.py
+++ b/vmware_aria_operations_integration_sdk/serialization.py
@@ -48,10 +48,19 @@ from vmware_aria_operations_integration_sdk.validation.endpoint_url_validator im
     validate_endpoint_urls,
 )
 from vmware_aria_operations_integration_sdk.validation.highlights import (
+    highlight_event_growth,
+)
+from vmware_aria_operations_integration_sdk.validation.highlights import (
     highlight_metric_growth,
 )
 from vmware_aria_operations_integration_sdk.validation.highlights import (
     highlight_object_growth,
+)
+from vmware_aria_operations_integration_sdk.validation.highlights import (
+    highlight_property_growth,
+)
+from vmware_aria_operations_integration_sdk.validation.highlights import (
+    highlight_property_value_growth,
 )
 from vmware_aria_operations_integration_sdk.validation.relationship_validator import (
     validate_relationships,
@@ -194,7 +203,13 @@ class LongCollectionBundle:
         """
 
         result = Result()
-        for _validate in [highlight_object_growth, highlight_metric_growth]:
+        for _validate in [
+            highlight_object_growth,
+            highlight_metric_growth,
+            highlight_property_growth,
+            highlight_property_value_growth,
+            highlight_event_growth,
+        ]:
             result += _validate(self.long_collection_statistics)
 
         return result

--- a/vmware_aria_operations_integration_sdk/validation/adapter_definition_validator.py
+++ b/vmware_aria_operations_integration_sdk/validation/adapter_definition_validator.py
@@ -54,4 +54,7 @@ def validate_adapter_definition(
     except Exception as e:
         result.with_error(f"Unable to validate the response json: '{e}'")
 
+    if not (result.error_count or result.warning_count):
+        result.with_success("Json response from adapter validates against the schema.")
+
     return result

--- a/vmware_aria_operations_integration_sdk/validation/adapter_definition_validator.py
+++ b/vmware_aria_operations_integration_sdk/validation/adapter_definition_validator.py
@@ -54,7 +54,7 @@ def validate_adapter_definition(
     except Exception as e:
         result.with_error(f"Unable to validate the response json: '{e}'")
 
-    if not (result.error_count or result.warning_count):
+    if result.issue_count() == 0:
         result.with_success("Json response from adapter validates against the schema.")
 
     return result

--- a/vmware_aria_operations_integration_sdk/validation/api_response_validation.py
+++ b/vmware_aria_operations_integration_sdk/validation/api_response_validation.py
@@ -74,7 +74,7 @@ def _validate_api_response(
     except Exception as e:
         result.with_error(f"Unable to validate the response json: '{e}'")
 
-    if not (result.error_count or result.warning_count):
+    if result.issue_count() == 0:
         result.with_success("Json response from adapter validates against the schema.")
 
     return result

--- a/vmware_aria_operations_integration_sdk/validation/api_response_validation.py
+++ b/vmware_aria_operations_integration_sdk/validation/api_response_validation.py
@@ -74,4 +74,7 @@ def _validate_api_response(
     except Exception as e:
         result.with_error(f"Unable to validate the response json: '{e}'")
 
+    if not (result.error_count or result.warning_count):
+        result.with_success("Json response from adapter validates against the schema.")
+
     return result

--- a/vmware_aria_operations_integration_sdk/validation/describe_checks.py
+++ b/vmware_aria_operations_integration_sdk/validation/describe_checks.py
@@ -266,6 +266,11 @@ def cross_check_collection_with_describe(
             f"Unable to cross check collection against describe.xml: '{e}'"
         )
 
+    if not (result.error_count or result.warning_count):
+        result.with_success(
+            "Collection cross checked against describe.xml successfully."
+        )
+
     return result
 
 

--- a/vmware_aria_operations_integration_sdk/validation/describe_checks.py
+++ b/vmware_aria_operations_integration_sdk/validation/describe_checks.py
@@ -266,7 +266,7 @@ def cross_check_collection_with_describe(
             f"Unable to cross check collection against describe.xml: '{e}'"
         )
 
-    if not (result.error_count or result.warning_count):
+    if result.issue_count() == 0:
         result.with_success(
             "Collection cross checked against describe.xml successfully."
         )

--- a/vmware_aria_operations_integration_sdk/validation/endpoint_url_validator.py
+++ b/vmware_aria_operations_integration_sdk/validation/endpoint_url_validator.py
@@ -23,6 +23,9 @@ def validate_endpoint(endpoint: str) -> Result:
         result.with_error(f"Endpoint '{endpoint}' protocol must be 'https'.")
     elif type(url_validation_result) is ValidationFailure:
         result.with_error(f"Endpoint '{endpoint}' is not a valid URL.")
+
+    if not (result.error_count or result.warning_count):
+        result.with_success(f"{endpoint} is a valid URL.")
     return result
 
 

--- a/vmware_aria_operations_integration_sdk/validation/endpoint_url_validator.py
+++ b/vmware_aria_operations_integration_sdk/validation/endpoint_url_validator.py
@@ -24,7 +24,7 @@ def validate_endpoint(endpoint: str) -> Result:
     elif type(url_validation_result) is ValidationFailure:
         result.with_error(f"Endpoint '{endpoint}' is not a valid URL.")
 
-    if not (result.error_count or result.warning_count):
+    if result.issue_count() == 0:
         result.with_success(f"{endpoint} is a valid URL.")
     return result
 

--- a/vmware_aria_operations_integration_sdk/validation/highlights.py
+++ b/vmware_aria_operations_integration_sdk/validation/highlights.py
@@ -28,6 +28,8 @@ High Object growth may affect Aria Operations' performance over time.
 - Check that object identifiers are not changing. 
 - Ensure that there are no short-lived objects (eg. sessions)."""
             )
+    else:
+        highlights.with_success("No abnormal object growth found")
     return highlights
 
 
@@ -52,6 +54,8 @@ High metric growth may affect Aria Operations' performance over time.
 Metric growth is caused by new or changing metric keys. One way to ensure metric keys are the same is to use 
 constants to describe their keys; Aria Operations works best with a constant set of metrics per object type."""
             )
+    else:
+        highlights.with_success("No abnormal metric growth found")
     return highlights
 
 
@@ -76,6 +80,8 @@ High property growth may affect Aria Operations' performance over time.
 Property growth is caused by new or changing property keys. One way to ensure property keys are the same is to use 
 constants to describe their keys; Aria Operations works best with a constant set of properties per object type."""
             )
+    else:
+        highlights.with_success("No abnormal property growth found")
 
     return highlights
 
@@ -120,6 +126,8 @@ or the value changes frequently, consider a metric with a numeric value. For exa
 stamp as a property to record the last backup date, should be replaced. A possible alternative could be a metric that counts
 days since last backup."""
             )
+    else:
+        highlights.with_success("No abnormal property value growth found")
 
     return highlights
 
@@ -151,6 +159,8 @@ An excessive number of events may indicate a bug or over-reporting.
 Overreporting can occur when an API reports all events instead of active events, and the Adapter creates more
 and more events each time. Filtering events based on status or a time window may fix this issue."""
                 )
+    else:
+        highlights.with_success("No abnormal event growth found")
     return highlights
 
 

--- a/vmware_aria_operations_integration_sdk/validation/relationship_validator.py
+++ b/vmware_aria_operations_integration_sdk/validation/relationship_validator.py
@@ -138,4 +138,8 @@ def validate_relationships(
         )
     except Exception as e:
         result.with_error(f"Unable to validate relationships: '{e}'")
+
+    if not (result.error_count or result.warning_count):
+        result.with_success(f"No cycles found in relationships.")
+
     return result

--- a/vmware_aria_operations_integration_sdk/validation/relationship_validator.py
+++ b/vmware_aria_operations_integration_sdk/validation/relationship_validator.py
@@ -139,7 +139,7 @@ def validate_relationships(
     except Exception as e:
         result.with_error(f"Unable to validate relationships: '{e}'")
 
-    if not (result.error_count or result.warning_count):
+    if result.issue_count() == 0:
         result.with_success(f"No cycles found in relationships.")
 
     return result

--- a/vmware_aria_operations_integration_sdk/validation/result.py
+++ b/vmware_aria_operations_integration_sdk/validation/result.py
@@ -26,6 +26,9 @@ class Result:
         self.messages = self.messages + other.messages
         return self
 
+    def issue_count(self) -> int:
+        return self.error_count + self.warning_count
+
     def with_error(self, error: str) -> None:
         self.error_count += 1
         self.messages.append((ResultLevel.ERROR, error))

--- a/vmware_aria_operations_integration_sdk/validation/result.py
+++ b/vmware_aria_operations_integration_sdk/validation/result.py
@@ -11,6 +11,7 @@ class ResultLevel(Enum):
     ERROR = 1
     WARNING = 2
     INFORMATION = 3
+    SUCCESS = 4
 
 
 class Result:
@@ -35,3 +36,6 @@ class Result:
 
     def with_information(self, information: str) -> None:
         self.messages.append((ResultLevel.INFORMATION, information))
+
+    def with_success(self, success: str) -> None:
+        self.messages.append((ResultLevel.SUCCESS, success))


### PR DESCRIPTION
* When a test connection fails, it now informs the user:
   <img width="1230" alt="image" src="https://user-images.githubusercontent.com/3310870/229168515-38aa7830-be7d-4bfe-bc61-f5c3d6fe1f66.png">
* Adds a 'success' result that writes to 'validation.log', for better visibility into what tests are being run.
* Adds missing highlight tests to long-run validation -- the tests for `property-growth`, `property-value-growth`, and `event-growth` were never being run. Example 'validation.log' after successful long run:
   ```
   SUCCESS: No abnormal object growth found
   SUCCESS: No abnormal metric growth found
   SUCCESS: No abnormal property growth found
   SUCCESS: No abnormal property value growth found
   SUCCESS: No abnormal event growth found
   ```
* Related: I've added #103 

Resolves #87 