### PR TITLE
Windows 10 & 11 Ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 VMware Aria Operations Integration SDK
 --------------------------------------
 ## Unreleased
+* Fixes issue where psutil version would cause python build to fail
+* Standardize encoding of properties file to 'utf-8'
 * Adds two flags to mp-test for controlling collection parameters:
   * '--collection-number': Sets the collection number. This is useful for testing functionality that only occurs on some collection cycles.
   * '--collection-window-duration': Sets the duration of the collection window. This is useful for testing how the adapter behaves for longer or shorter collection windows.

--- a/vmware_aria_operations_integration_sdk/mp_init.py
+++ b/vmware_aria_operations_integration_sdk/mp_init.py
@@ -427,7 +427,7 @@ def build_project_structure(
         # create template requirements.txt
         requirements_file = os.path.join(path, "adapter_requirements.txt")
         with open(requirements_file, "w") as requirements:
-            requirements.write("psutil==5.9.0\n")
+            requirements.write("psutil==5.9.4\n")
             requirements.write("vmware-aria-operations-integration-sdk-lib==0.7.*\n")
 
         # create development requirements file

--- a/vmware_aria_operations_integration_sdk/propertiesfile.py
+++ b/vmware_aria_operations_integration_sdk/propertiesfile.py
@@ -19,7 +19,7 @@ def load_properties(properties_file: str) -> dict:
 
 
 def write_properties(properties: dict, filename: str) -> bool:
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         for _property in properties.keys():
             f.write(str(_property) + " = " + str(properties[_property]) + "\n")
     return True


### PR DESCRIPTION
* Fix issue where 'psutil'  to version 5.9.4 to prevent dependency on a template to crash build
* Standardize encoding of properties file to 'utf-8' to prevent encoding errors on Windows

## Before:
![image](https://user-images.githubusercontent.com/22756465/230205052-b8437f43-aecf-41c1-8e6c-d2ee42b4ac55.png)

## After:
![image](https://user-images.githubusercontent.com/22756465/230205308-b040a515-71a2-4987-aa6a-219cab835f34.png)



