### PR TITLE
Fix bold text for All Objects path

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ It should return successfully, then click `ADD`.
 
 By default, a collection will run every 5 minutes. The first collection should happen immediately. However, newly-created
 objects cannot have metrics, properties, and events added to them. After the second collection, approximately five
-minutes later, the objects' metrics, properties, and events should appear. These can be checked by navigating to **
-Environment &rarr; Object Browser &rarr; All Objects** and expanding the Adapter and associated object types and object.
+minutes later, the objects' metrics, properties, and events should appear. These can be checked by navigating to 
+**Environment &rarr; Object Browser &rarr; All Objects** and expanding the Adapter and associated object types and object.
 
 ![CPU Idle Time](doc/test-adapter-cpu-idle-time.png)
 *The CPU object's `idle-time` metric in a Management Pack named `QAAdapterName`.*


### PR DESCRIPTION
Before:
<img width="841" alt="image" src="https://github.com/vmware/vmware-aria-operations-integration-sdk/assets/1360302/f16b866f-420b-4b5d-b5a2-d40da8541bf8">


After:
<img width="837" alt="image" src="https://github.com/vmware/vmware-aria-operations-integration-sdk/assets/1360302/aadc32c7-0551-4bea-b830-7845c484c197">
