### PR TITLE
container_registry in config file 

### DIFF
--- a/vmware_aria_operations_integration_sdk/mp_build.py
+++ b/vmware_aria_operations_integration_sdk/mp_build.py
@@ -188,7 +188,6 @@ def validate_container_registry(
     container_registry: Optional[str],
     **kwargs: Any,
 ) -> str:
-
     if not container_registry:
         default_registry_value = get_config_value(
             CONFIG_DEFAULT_CONTAINER_REGISTRY_PATH_KEY


### PR DESCRIPTION
- save config value if pushing succeeds 
- We shouldn't log into the Docker Hub when the user provides an empty string because we would still need the names space and repository name.
- related #114 