### PR TITLE
Task/remove adapter3 suffix

### DIFF
--- a/docs/guides/extending_an_existing_management_pack.md
+++ b/docs/guides/extending_an_existing_management_pack.md
@@ -259,7 +259,7 @@ These will be used to ensure that the metrics are attached to existing MySQL obj
 rather than creating new ones.
 
 To get this information, we will `ssh` into the collector where the MySQL management
-pack is running. Then `cd` to `$ALIVE_BASE/user/plugin/inbound/mysql_adapter3/conf/`.
+pack is running. Then `cd` to `$ALIVE_BASE/user/plugin/inbound/mysql/conf/`.
 From there, open the `describe.xml` file. The Adapter Kind key is at the top on the
 fourth line:
 ```xml

--- a/docs/troubleshooting_and_faq/logs.md
+++ b/docs/troubleshooting_and_faq/logs.md
@@ -8,7 +8,7 @@ project.
 
 ###  Where are the adapter logs stored in VMware Aria Operations?
 
-Logs are generated and stored on the cloud proxy where the adapter is running at `$ALIVE_BASE/user/log/adapter/<ADAPTERKEY>_adapter3/<ADAPTER_INTERNAL_INSTANCE_ID>`.
+Logs are generated and stored on the cloud proxy where the adapter is running at `$ALIVE_BASE/user/log/adapter/<ADAPTERKEY>/<ADAPTER_INTERNAL_INSTANCE_ID>`.
 
 `ADAPTERKEY` should match the adapter key used in the `manifest.txt`, and the `ADAPTER_INTERNAL_INSTANCE_ID` should match the Internal ID
 found in VMware Aria Operations at **Environment &rarr; Inventory &rarr; Adapter Instances &rarr; &lt;ADAPTER_DISPLAY_NAME&gt; &rarr; &lt;ADAPTER_INSTANCE&gt;** in the rightmost column.
@@ -62,7 +62,7 @@ The logger only needs to be configured once; to generate logs in other files, si
 
 ###  How do I change the server and/or adapter log level?
 
-You can set the log levels for the server and adapter inside the `loglevels.cfg` file, which is located in `logs/loglevels.cfg` locally and on the cloud proxy at `$ALIVE_BASE/user/log/adapters/<ADAPTERKEY>_adapter3/<ADAPTER_INTERNAL_INSTANCE_ID>/loglevels.cfg`.
+You can set the log levels for the server and adapter inside the `loglevels.cfg` file, which is located in `logs/loglevels.cfg` locally and on the cloud proxy at `$ALIVE_BASE/user/log/adapters/<ADAPTERKEY>/<ADAPTER_INTERNAL_INSTANCE_ID>/loglevels.cfg`.
 If the file does not exist, the system generates it after a collection/test.
 
 `ADAPTERKEY` should match the name of the adapter used in the `manifest.txt`, and the `ADAPTER_INTERNAL_INSTANCE_ID` should match the Internal ID

--- a/vmware_aria_operations_integration_sdk/mp_build.py
+++ b/vmware_aria_operations_integration_sdk/mp_build.py
@@ -388,7 +388,7 @@ async def build_pak_file(
                 image.remove(force=True)
 
         with Spinner("Assembling Pak File"):
-            adapter_dir = adapter_kind_key + "_adapter3"
+            adapter_dir = adapter_kind_key
             mkdir(adapter_dir)
             shutil.copytree("conf", os.path.join(adapter_dir, "conf"))
             if not os.path.exists(os.path.join(adapter_dir, "conf", "describe.xml")):


### PR DESCRIPTION
The log path and adapter path no long have `_adapter3` appended to the adapter directory.

Resolves #237 