### PR TITLE
Remove unnecessary filesystem copy

### DIFF
--- a/vmware_aria_operations_integration_sdk/mp_build.py
+++ b/vmware_aria_operations_integration_sdk/mp_build.py
@@ -591,6 +591,7 @@ def main() -> None:
         mkdir(build_dir)
 
         try:
+            mkdir(temp_dir)
             os.chdir(temp_dir)
 
             pak_file = asyncio.run(

--- a/vmware_aria_operations_integration_sdk/mp_build.py
+++ b/vmware_aria_operations_integration_sdk/mp_build.py
@@ -286,8 +286,8 @@ def fix_describe(describe_adapter_kind_key: Optional[str], manifest_file: str) -
     if not selection_prompt(
         f"Update manifest.txt with adapter kind from describe.xml ('{describe_adapter_kind_key}')?",
         [(True, "Yes"), (False, "No")],
-        "Select 'Yes' to update the 'manifest.txt' file and continue with the build. Select 'No' to exit without "
-        "building and fix the issue manually.",
+        "Select 'Yes' to update the 'manifest.txt' file and continue with the build. "
+        "Select 'No' to exit without building and fix the issue manually.",
     ):
         exit(1)
     manifest = {}
@@ -591,22 +591,6 @@ def main() -> None:
         mkdir(build_dir)
 
         try:
-            # TODO: remove this copy and add logic to zip files from the source
-            shutil.copytree(
-                project.path,
-                temp_dir,
-                ignore=shutil.ignore_patterns(
-                    "build",
-                    "logs",
-                    "Dockerfile",
-                    "adapter_requirements",
-                    "commands.cfg",
-                    ".git",
-                    ".gitignore",
-                ),
-                dirs_exist_ok=True,
-            )
-
             os.chdir(temp_dir)
 
             pak_file = asyncio.run(
@@ -620,7 +604,8 @@ def main() -> None:
             )
 
             if os.path.exists(os.path.join(build_dir, pak_file)):
-                # NOTE: we could ask the user if they want to overwrite the current file instead of always deleting it
+                # NOTE: we could ask the user if they want to overwrite the current
+                # file instead of always deleting it
                 logger.debug("Deleting old pak file")
                 rm(os.path.join(build_dir, pak_file))
 
@@ -631,8 +616,8 @@ def main() -> None:
             if os.path.exists(temp_dir):
                 logger.debug(f"Deleting directory: '{temp_dir}'")
                 if os.getcwd() == temp_dir:
-                    # Change working directory to the build directory, otherwise we won't be able to delete the
-                    # directory in Windows based systems
+                    # Change working directory to the project directory, otherwise we
+                    # won't be able to delete the directory in Windows-based systems
                     os.chdir(project_dir)
                 rmdir(temp_dir)
     except DockerWrapperError as error:


### PR DESCRIPTION
`mp-build` was copying the project directory to a temporary location when building the pack file, but then reading project files from the original location.

Removing the copy saves a good amount of time when `mp-build` initializes, because of the (potential) size of virtual environments that were included in the copy.

I verified that removing the copy does not affect the built management packs, and reduces the time it takes to start building the project. I left the temporary directory in place, as there are some writes to the current directory which are good to keep separate from the project directory (even if they are cleaned up in most cases).

Resolves #239 

Before:
![mp-build](https://github.com/vmware/vmware-aria-operations-integration-sdk/assets/3310870/d9732e21-b8a4-4ec6-86d3-0003b1d4d8ef)


After:

![](http://g.recordit.co/5mZhoTudwS.gif)
