### PR TITLE
Add Empty field validation for CLI Suite API prompts

### DIFF
--- a/vmware_aria_operations_integration_sdk/constant.py
+++ b/vmware_aria_operations_integration_sdk/constant.py
@@ -49,9 +49,9 @@ CONNECTIONS_CONFIG_CONNECTION_CREDENTIAL_KEY = "credential"
 CONNECTIONS_CONFIG_CONNECTION_CERTIFICATES_KEY = "certificates"
 DEFAULT_MEMORY_LIMIT = 1024
 DEFAULT_PORT = 8080
-DEFAULT_SUITE_API_HOSTNAME = "placeholder_hostname"
-DEFAULT_SUITE_API_USERNAME = "placeholder_username"
-DEFAULT_SUITE_API_PASSWORD = "placeholder_password"
+DEFAULT_PLACEHOLDER_SUITE_API_HOSTNAME = "placeholder_hostname"
+DEFAULT_PLACEHOLDER_SUITE_API_USERNAME = "placeholder_username"
+DEFAULT_PLACEHOLDER_SUITE_API_PASSWORD = "placeholder_password"
 
 # Management pak
 REPO_NAME = "vmware-aria-operations-integration-sdk"

--- a/vmware_aria_operations_integration_sdk/mp_test.py
+++ b/vmware_aria_operations_integration_sdk/mp_test.py
@@ -41,10 +41,16 @@ from vmware_aria_operations_integration_sdk.constant import (
     CONNECTIONS_CONFIG_SUITE_API_USERNAME_KEY,
 )
 from vmware_aria_operations_integration_sdk.constant import CONNECTIONS_FILE_NAME
+from vmware_aria_operations_integration_sdk.constant import (
+    DEFAULT_PLACEHOLDER_SUITE_API_HOSTNAME,
+)
+from vmware_aria_operations_integration_sdk.constant import (
+    DEFAULT_PLACEHOLDER_SUITE_API_PASSWORD,
+)
+from vmware_aria_operations_integration_sdk.constant import (
+    DEFAULT_PLACEHOLDER_SUITE_API_USERNAME,
+)
 from vmware_aria_operations_integration_sdk.constant import DEFAULT_PORT
-from vmware_aria_operations_integration_sdk.constant import DEFAULT_SUITE_API_HOSTNAME
-from vmware_aria_operations_integration_sdk.constant import DEFAULT_SUITE_API_PASSWORD
-from vmware_aria_operations_integration_sdk.constant import DEFAULT_SUITE_API_USERNAME
 from vmware_aria_operations_integration_sdk.constant import ENDPOINTS_URLS_ENDPOINT
 from vmware_aria_operations_integration_sdk.constant import (
     GLOBAL_CONFIG_CONTAINER_PORT_KEY,
@@ -596,21 +602,23 @@ derived from the 'conf/describe.xml' file and are specific to each Management Pa
 def get_suite_api_connection_info(project: Project) -> Tuple[str, str, str]:
     suiteapi_hostname = get_config_value(
         CONNECTIONS_CONFIG_SUITE_API_HOSTNAME_KEY,
-        DEFAULT_SUITE_API_HOSTNAME,
+        DEFAULT_PLACEHOLDER_SUITE_API_HOSTNAME,
         os.path.join(project.path, CONNECTIONS_FILE_NAME),
     )
 
     suiteapi_username = get_config_value(
         CONNECTIONS_CONFIG_SUITE_API_USERNAME_KEY,
-        DEFAULT_SUITE_API_USERNAME,
+        DEFAULT_PLACEHOLDER_SUITE_API_USERNAME,
         os.path.join(project.path, CONNECTIONS_FILE_NAME),
     )
     suiteapi_password = get_config_value(
         CONNECTIONS_CONFIG_SUITE_API_PASSWORD_KEY,
-        DEFAULT_SUITE_API_PASSWORD,
+        DEFAULT_PLACEHOLDER_SUITE_API_PASSWORD,
         os.path.join(project.path, CONNECTIONS_FILE_NAME),
     )
-    has_default = False if suiteapi_hostname == DEFAULT_SUITE_API_HOSTNAME else True
+    has_default = (
+        False if suiteapi_hostname == DEFAULT_PLACEHOLDER_SUITE_API_HOSTNAME else True
+    )
     suite_api_prompt = "Set connection information for SuiteAPI calls? "
     description = ""
     if has_default:

--- a/vmware_aria_operations_integration_sdk/project.py
+++ b/vmware_aria_operations_integration_sdk/project.py
@@ -42,6 +42,15 @@ from vmware_aria_operations_integration_sdk.constant import (
 )
 from vmware_aria_operations_integration_sdk.constant import CONNECTIONS_FILE_NAME
 from vmware_aria_operations_integration_sdk.constant import DEFAULT_MEMORY_LIMIT
+from vmware_aria_operations_integration_sdk.constant import (
+    DEFAULT_PLACEHOLDER_SUITE_API_HOSTNAME,
+)
+from vmware_aria_operations_integration_sdk.constant import (
+    DEFAULT_PLACEHOLDER_SUITE_API_PASSWORD,
+)
+from vmware_aria_operations_integration_sdk.constant import (
+    DEFAULT_PLACEHOLDER_SUITE_API_USERNAME,
+)
 from vmware_aria_operations_integration_sdk.logging_format import CustomFormatter
 from vmware_aria_operations_integration_sdk.logging_format import PTKHandler
 from vmware_aria_operations_integration_sdk.propertiesfile import load_properties
@@ -113,17 +122,17 @@ class Connection:
 
         default_hostname = get_config_value(
             CONNECTIONS_CONFIG_SUITE_API_HOSTNAME_KEY,
-            "hostname",
+            DEFAULT_PLACEHOLDER_SUITE_API_HOSTNAME,
             os.path.join(path, CONNECTIONS_FILE_NAME),
         )
         default_username = get_config_value(
             CONNECTIONS_CONFIG_SUITE_API_USERNAME_KEY,
-            "username",
+            DEFAULT_PLACEHOLDER_SUITE_API_USERNAME,
             os.path.join(path, CONNECTIONS_FILE_NAME),
         )
         default_password = get_config_value(
             CONNECTIONS_CONFIG_SUITE_API_PASSWORD_KEY,
-            "password",
+            DEFAULT_PLACEHOLDER_SUITE_API_PASSWORD,
             os.path.join(path, CONNECTIONS_FILE_NAME),
         )
 


### PR DESCRIPTION
- Add validation to suite API-related questions, so the user can't submit an empty string.
- Change the name of the constant-use ad placeholders to improve readability.