### PR TITLE
Snmp template improvements

### DIFF
--- a/samples/snmp-template-mp/.gitignore
+++ b/samples/snmp-template-mp/.gitignore
@@ -1,5 +1,5 @@
 logs
 build
 config.json
+connections.json
 venv-SNMP Sample MP
-

--- a/samples/snmp-template-mp/adapter_requirements.txt
+++ b/samples/snmp-template-mp/adapter_requirements.txt
@@ -1,3 +1,3 @@
-vmware-aria-operations-integration-sdk-lib==0.7.*
+vmware-aria-operations-integration-sdk-lib==0.8.*
 pysnmp==4.4.12
 pyasn1==0.4.8

--- a/samples/snmp-template-mp/app/adapter.py
+++ b/samples/snmp-template-mp/app/adapter.py
@@ -174,7 +174,7 @@ def collect(adapter_instance: AdapterInstance) -> CollectResult:
             client = SNMPClient(adapter_instance)
 
             # Get some sample data from the SNMPv2-MIB. Most SNMP devices implement
-            # this MIB.
+            # this MIB. Omit index_count (or use index_count=0) to retrieve scalar data.
             for data, indices in client.get_OIDs(
                 [
                     SYSTEM_DESC,

--- a/samples/snmp-template-mp/app/pysnmp_util.py
+++ b/samples/snmp-template-mp/app/pysnmp_util.py
@@ -1,6 +1,9 @@
 #  Copyright 2023 VMware, Inc.
 #  SPDX-License-Identifier: Apache-2.0
 from logging import Logger
+from typing import Any
+from typing import Generator
+from typing import Iterator
 from typing import Optional
 from typing import Union
 
@@ -19,17 +22,27 @@ from constants import PRIVACY_PROTOCOLS
 from constants import SNMP_V2
 from constants import SNMP_V3
 from constants import USER
-from pysnmp.hlapi import *
+from pysnmp.hlapi import CommunityData
+from pysnmp.hlapi import ContextData
+from pysnmp.hlapi import getCmd
+from pysnmp.hlapi import nextCmd
+from pysnmp.hlapi import SnmpEngine
+from pysnmp.hlapi import UdpTransportTarget
+from pysnmp.hlapi import usmAesCfb128Protocol
+from pysnmp.hlapi import usmHMACSHAAuthProtocol
+from pysnmp.hlapi import UsmUserData
+from pysnmp.smi.rfc1902 import ObjectIdentity
+from pysnmp.smi.rfc1902 import ObjectType
 
 
 class SNMPClient:
-    def __init__(self, adapter_instance):
+    def __init__(self, adapter_instance: AdapterInstance) -> None:
         self._hostname = adapter_instance.get_identifier_value(HOSTNAME)
         self._port = int(adapter_instance.get_identifier_value(PORT))
         self._user_data = get_user_data(adapter_instance)
 
-    def get_command(self, *var_binds, **kwargs):
-        return getCmd(
+    def get_command(self, *var_binds: Any, **kwargs: Any) -> Iterator:
+        return getCmd(  # type: ignore
             SnmpEngine(),
             self._user_data,
             UdpTransportTarget((self._hostname, self._port)),
@@ -38,8 +51,8 @@ class SNMPClient:
             **kwargs,
         )
 
-    def next_command(self, *var_binds, **kwargs):
-        return nextCmd(
+    def next_command(self, *var_binds: Any, **kwargs: Any) -> Iterator:
+        return nextCmd(  # type: ignore
             SnmpEngine(),
             self._user_data,
             UdpTransportTarget((self._hostname, self._port)),
@@ -47,6 +60,52 @@ class SNMPClient:
             *var_binds,
             **kwargs,
         )
+
+    def get_OIDs(
+        self,
+        oids: list[str],
+        index_count: int = 0,
+        logger: Optional[Logger] = None,
+        result: Optional[Union[CollectResult, TestResult]] = None,
+        **kwargs: Any,
+    ) -> Generator[tuple[dict[str, Any], tuple[str, ...]], None, None]:
+        var_binds = [ObjectType(ObjectIdentity(oid)) for oid in oids]
+        # Looking up the MIB gets more metadata about the OID we are passing in
+        # (and allows querying by name instead of OID), but the number of
+        # built-in MIBS in PySNMP is limited. Since we don't need them, we'll
+        # disable this feature by default.
+        kwargs.setdefault("lookupMib", False)
+        kwargs.setdefault("lexicographicMode", False)
+
+        def get_oid_and_index(key: str) -> tuple[str, tuple[str, ...]]:
+            oid, *indices_list = str(key).rsplit(".", index_count)
+            return oid, tuple(indices_list)
+
+        if index_count == 0:
+            iterator = self.get_command(*var_binds, **kwargs)
+        else:
+            iterator = self.next_command(*var_binds, **kwargs)
+        for error_indication, error_status, error_index, var_binds in iterator:
+            if handle_errors(
+                logger,
+                result,
+                error_indication,
+                error_status,
+                error_index,
+                var_binds,
+            ):
+                # If we got an error, log and continue
+                continue
+
+            # data = {key: value for (key, value) in var_binds}
+            data = {}
+            indices: tuple[str, ...] = ()
+            for key, value in var_binds:
+                oid, indices = get_oid_and_index(key)
+                data[oid] = value
+            if logger:
+                logger.debug(data)
+            yield data, indices
 
 
 def get_user_data(
@@ -75,15 +134,17 @@ def get_user_data(
             privProtocol=privacy_protocol,
             privKey=privacy_passphrase,
         )
+    else:
+        raise Exception(f"Unknown credential type: {adapter_instance.credential_type}")
 
 
 def handle_errors(
     logger: Optional[Logger],
     result: Optional[Union[CollectResult, TestResult]],
-    error_indication,
-    error_status,
-    error_index,
-    var_binds,
+    error_indication: Any,
+    error_status: Any,
+    error_index: Any,
+    var_binds: Any,
 ) -> bool:
     if error_indication:  # SNMP engine errors
         if logger:

--- a/samples/snmp-template-mp/requirements.txt
+++ b/samples/snmp-template-mp/requirements.txt
@@ -1,1 +1,1 @@
-vmware-aria-operations-integration-sdk==0.5.1
+vmware-aria-operations-integration-sdk==1.0.0


### PR DESCRIPTION
While writing the blog I found that there was too much boilerplate code in adapter.py that could be refactored, and that we needed more robust handling for tables and indices. This fixes those issues, and results in a much cleaner adapter.py.

* Update to SDK 1.0.0
* Update to Adapter Lib 0.8.0
* Refactor common code in 'adapter.py'
* Improve handing for Tables and Indices