### PR TITLE
Add Java Adapter Library CI to GitHub Actions

### DIFF
--- a/.github/workflows/aria-operations-integration-sdk.yaml
+++ b/.github/workflows/aria-operations-integration-sdk.yaml
@@ -44,7 +44,7 @@ jobs:
       if: ${{ always() }}
 
   python-lib:
-    name: Aria Operations Integration SDK Python Library
+    name: Aria Operations Integration SDK Python Adapter Library
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -78,3 +78,23 @@ jobs:
         path: lib/python/test-results-${{ matrix.python-version }}.xml
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}
+
+  java-lib:
+    name: Aria Operations Integration SDK Java Adapter Library
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: zulu
+        architecture: x64
+    - name: Setup and execute Gradle 'test' task
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: -p ./lib/java/AdapterLibrary/ test
+        gradle-executable: ./lib/java/AdapterLibrary/

--- a/.github/workflows/aria-operations-integration-sdk.yaml
+++ b/.github/workflows/aria-operations-integration-sdk.yaml
@@ -97,4 +97,4 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: -p ./lib/java/AdapterLibrary/ test
-        gradle-executable: ./lib/java/AdapterLibrary/
+        gradle-executable: ./lib/java/AdapterLibrary/gradlew

--- a/lib/java/AdapterLibrary/build.gradle.kts
+++ b/lib/java/AdapterLibrary/build.gradle.kts
@@ -14,8 +14,9 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:5.9.1"))
+    testImplementation(platform("org.junit:junit-bom:5.9.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
 }
@@ -25,9 +26,9 @@ tasks.test {
 }
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = "17"
 }
 val compileTestKotlin: KotlinCompile by tasks
 compileTestKotlin.kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = "17"
 }


### PR DESCRIPTION
Set up the Java Adapter Library tests to run with GitHub Actions.