### PR TITLE
Add TestResult, EndpointResult, and CollectResult classes

### DIFF
--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/Exceptions.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/Exceptions.kt
@@ -12,4 +12,16 @@ class IdentifierUniquenessException(message: String) : RuntimeException(message)
 /**
  * Exception when two objects with the same Key are added to the same CollectResult
  */
-class ObjectKeyAlreadyExistsException(message: String): Exception(message)
+class ObjectKeyAlreadyExistsException private constructor(message: String) : Exception(message) {
+    constructor(keys: Iterable<Key>) : this(constructMessage(keys))
+    constructor(key: Key) : this(constructMessage(listOf(key)))
+
+    companion object {
+        fun constructMessage(keys: Iterable<Key>): String =
+            if (keys.count() > 1) {
+                "Duplicate objects with keys $keys already exist in the CollectResult"
+            } else {
+                "A duplicate object with key ${keys.first()} already exist in the CollectResult."
+            }
+    }
+}

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/Exceptions.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/Exceptions.kt
@@ -19,9 +19,9 @@ class ObjectKeyAlreadyExistsException private constructor(message: String) : Exc
     companion object {
         fun constructMessage(keys: Iterable<Key>): String =
             if (keys.count() > 1) {
-                "Duplicate objects with keys $keys already exist in the CollectResult"
+                "Duplicate objects with keys $keys already exist in the CollectResult."
             } else {
-                "A duplicate object with key ${keys.first()} already exist in the CollectResult."
+                "A duplicate object with key ${keys.first()} already exists in the CollectResult."
             }
     }
 }

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/NamedPipe.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/NamedPipe.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+@file:JvmName("NamedPipe")
+
+package com.vmware.aria.operations
+
+import kotlinx.serialization.json.JsonElement
+
+
+object Pipes {
+    lateinit var input: String
+    lateinit var output: String
+}
+
+/**
+ * Reads data from the input pipe.
+ *
+ * @param inputPipe The path to the input pipe.
+ * @return The data read from the input pipe, or null if there was an error.
+ */
+fun readFromPipe(inputPipe: String = Pipes.input): JsonElement? {
+    // Placeholder for use in *Result classes
+    return null
+}
+
+/**
+ * Writes data to the output pipe
+ * @param outputPipe The path to the output pipe
+ * @param result The (json) data to write to the output pipe
+ */
+fun writeToPipe(result: JsonElement, outputPipe: String = Pipes.output) {
+    // Placeholder for use in *Result classes
+}

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/Object.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/Object.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 /**
- * Represents an Object (resource) in vROps.
+ * Represents an Object (resource) in VMware Aria Operations.
  *
  * Contains [Metrics][Metric], [Properties][Property], [Events][Event], and relationships
  * to other [Objects][Object]. Each [Object] is identified by a unique [Key].
@@ -17,6 +17,25 @@ import kotlinx.serialization.Transient
  */
 @Serializable
 open class Object(val key: Key) {
+    /**
+     * Represents an Object (resource) in VMware Aria Operations.
+     *
+     * Contains [Metrics][Metric], [Properties][Property], [Events][Event], and relationships
+     * to other [Objects][Object]. Each [Object] is identified by a unique [Key].
+     *
+     * @param adapterType The adapter type of the object
+     * @param objectType The type of the object
+     * @param name The name of the object
+     * @param identifiers An optional list of [Identifiers][Identifier] for the object
+     */
+    @JvmOverloads
+    constructor(
+        adapterType: String,
+        objectType: String,
+        name: String,
+        identifiers: List<Identifier> = emptyList(),
+    ) : this(Key(adapterType, objectType, name, identifiers))
+
     private val metrics: MutableSet<Metric> = mutableSetOf()
     private val properties: MutableSet<Property> = mutableSetOf()
     private val events: MutableSet<Event> = mutableSetOf()
@@ -372,6 +391,10 @@ open class Object(val key: Key) {
      * @param children A collection of child [Objects][Object].
      */
     fun addChildren(children: Iterable<Object>) {
+        // Set hasUpdatedChildren even if the 'children' collection is empty
+        // so that when CollectResult.updateRelationships is PER_OBJECT, there is a way
+        // to delete all child relationships.
+        hasUpdatedChildren = true
         for (child in children) {
             addChild(child)
         }

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/Result.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/Result.kt
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+@file:JvmName("Result")
+
+package com.vmware.aria.operations
+
+import com.vmware.aria.operations.definition.AdapterDefinition
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+
+enum class RelationshipUpdateModes {
+    /**
+     * If [CollectResult.updateRelationships] is [ALL], all relationships between objects are
+     * returned. This mode will remove any currently-existing relationships in VMware
+     * Aria Operations that are not present in the Result.
+     */
+    ALL,
+
+    /**
+     * If [CollectResult.updateRelationships] is [NONE], no relationships will be returned, even if
+     * there are relationships between objects in the Result. All currently-existing
+     * relationships in VMware Aria Operations will be preserved.
+     */
+    NONE,
+
+    /**
+     * If [CollectResult.updateRelationships] is [AUTO] (or not explicitly set), then the mode will
+     * behave like 'ALL' if any object in the Result has at least one relationship,
+     * otherwise the mode will behave like 'NONE' if no objects have any relationships in
+     * the Result. This default behavior makes it easy to skip collecting all relationships
+     * for a collection without overwriting previously-collected relationships, e.g., for
+     * performance reasons.
+     */
+    AUTO,
+
+    /**
+     * If [CollectResult.updateRelationships] is [PER_OBJECT], then only objects with updated
+     * relationships will be returned. This is similar to 'AUTO' except that if an
+     * object's child relationships have not been updated/set (by calling 'add_child' or
+     * 'add_children'), existing child relationships in VMware Aria Operations will be
+     * preserved. This means that to remove all relationships from an [Object]
+     * (without setting any new relationships), the adapter must call [Object.addChildren] on
+     * the object with an empty collection of children. This mode is useful for updating a
+     * subset of objects' relationships in a collection, but requires more care to
+     * ensure relationships are removed when appropriate.
+     */
+    PER_OBJECT,
+}
+
+/**
+ * Class for managing the results of an Adapter Instance 'connection' test
+ */
+@Serializable
+class TestResult {
+    private var errorMessage: String? = null
+
+    /**
+     * @return true if the TestResult represents a successful test
+     */
+    fun isSuccess() = errorMessage == null
+
+    /**
+     * Set the adapter instance connection test to failed, and display the given
+     * error message.
+     *
+     * If this method is called multiple times, only the most recent error message
+     * will be recorded. If [errorMessage] is set, the test is considered failed.
+     *
+     * @param errorMessage The error message to present to the user.
+     */
+    fun withError(errorMessage: String) = apply {
+        this.errorMessage = errorMessage
+    }
+
+    /**
+     * @return Returns a JSON representation of this [TestResult] in the format required by
+     * Aria Operations, indicating either a successful test, or a failed test with
+     * error message.
+     */
+    val json: JsonElement
+        get() = Json.encodeToJsonElement(this)
+
+    /**
+     * Opens the output pipe and sends result directly back to the server
+     *
+     * This method can only be called once per collection.
+     *
+     * @param outputPipe The path to the output pipe.
+     */
+    fun sendResults(outputPipe: String = Pipes.output) {
+        writeToPipe(json, outputPipe)
+    }
+}
+
+/**
+ * Class for managing the results of an adapter's getEndpointURLs call
+ *
+ * The result of is a set of urls that the adapter will connect to.
+ * Aria Operations will then attempt to connect to each of these urls securely,
+ * and prompt the user to accept or reject the certificate presented by each URL.
+ */
+@Serializable
+class EndpointResult {
+    private val endpointUrls = mutableSetOf<String>()
+
+    /**
+     * Adds an endpoint to the set of endpoints Aria Operations will test for
+     * certificate validation.
+     *
+     * If this method is called multiple times, each url will be called by Aria
+     * Operations.
+     *
+     * @param endpoint A string containing the url
+     */
+    fun withEndpoint(endpoint: String) = apply {
+        this.endpointUrls.add(endpoint)
+    }
+
+    /**
+     * @return Returns a JSON representation of this [EndpointResult] in the format required by
+     * Aria Operations.
+     */
+    val json: JsonElement
+        get() = Json.encodeToJsonElement(this)
+
+    /**
+     * Opens the output pipe and sends results directly back to the server
+     * This method can only be called once per collection.
+     * @param outputPipe The path to the output pipe.
+     */
+    fun sendResults(outputPipe: String = Pipes.output) {
+        writeToPipe(json, outputPipe)
+    }
+}
+
+/**
+ * Class for managing the results of an adapter's collection call.
+ *
+ * A [CollectResult] contains [Objects][Object], which can be added at initialization or later.
+ * Each [Object] has a [Key] containing one or more [Identifiers][Identifier] plus the object type
+ * and adapter type. [Keys][Key] must be unique across objects in a [CollectResult].
+ *
+ * @param objectList An optional [List] of objects to send to Aria Operations. [Objects][Object] can be
+ * added later using [CollectResult.addObject]. Defaults to an empty list.
+ * @param targetDefinition an optional description of the returned objects, used for validation
+ * purposes. Defaults to null.
+ */
+class CollectResult(
+    objectList: List<Object> = emptyList(),
+    private val targetDefinition: AdapterDefinition? = null,
+) {
+    private val objects = mutableMapOf<Key, Object>()
+    private val adapterType: String?
+    private var errorMessage: String? = null
+    var updateRelationships = RelationshipUpdateModes.AUTO
+
+    init {
+        addObjects(objectList)
+        adapterType = targetDefinition?.adapterType
+    }
+
+    fun isSuccess() = errorMessage == null
+
+    /**
+     * Set the Adapter Instance to an error state with the provided message.
+     *
+     * If this method is called multiple times, only the most recent error message
+     * will be recorded. If [errorMessage] is set, no other [Objects][Object] (including the
+     * object's [Events][Event], [Properties][Property], [Metrics][Metric], and Relationships)
+     * will be returned in the [CollectResult].
+     *
+     * @param errorMessage A string containing the error message
+     */
+    fun withError(errorMessage: String) = apply {
+        this.errorMessage = errorMessage
+    }
+
+    /**
+     * An object is external if it was created by a different adapter than this one.
+     *
+     * @param obj [Object] to test if it is external.
+     * @return true if the [Object Type][Object.objectType] of [obj] does not match the object type set by
+     * [targetDefinition]. If [targetDefinition] has not been set, this always returns false.
+     */
+    private fun objectIsExternal(obj: Object) =
+        adapterType != null && adapterType != obj.adapterType
+
+    /**
+     * Get or create the [Object] with the [Key] given by the provided identification
+     * ([adapterType], [objectType], name, and identifiers).
+     *
+     * This is the preferred method for creating new Objects. If this method is used
+     * exclusively, all [Object] references with the same key will point to the same
+     * object.
+     *
+     * If an [Object] with the same key already exists in the [CollectResult], return that
+     * [Object], otherwise create a new [Object], add it to the [CollectResult], and return it.
+     * See discussion on keys in the documentation for the [Key] class.
+     *
+     * If this method is used to create an [Object], it does not need to be added
+     * later using [addObject] or [addObjects].
+     *
+     * @param adapterType The adapter type of the object
+     * @param objectType The type of the object
+     * @param name The name of the object
+     * @param identifiers An optional list of [Identifiers][Identifier] for the object
+     *
+     * @return The [Object] with the given [Key]
+     */
+
+    @JvmOverloads
+    fun getOrCreateObject(
+        adapterType: String,
+        objectType: String,
+        name: String,
+        identifiers: List<Identifier> = emptyList(),
+    ): Object {
+        val key = Key(adapterType, objectType, name, identifiers)
+        return getOrCreateObject(key)
+    }
+
+    /**
+     * Get or create the object with key specified by the [key].
+     *
+     * This is the preferred method for creating new Objects. If this method is used
+     * exclusively, all [Object] references with the same key will point to the same
+     * object.
+     *
+     * If an [Object] with the same key already exists in the [CollectResult], return that
+     * [Object], otherwise create a new [Object], add it to the [CollectResult], and return it.
+     * See discussion on keys in the documentation for the [Key] class.
+     *
+     * If this method is used to create an [Object], it does not need to be added
+     * later using [addObject] or [addObjects].
+     *
+     * @param key The [Key] that identifies the object
+     * @return The [Object] with the given [Key]
+     */
+    fun getOrCreateObject(
+        key: Key,
+    ): Object {
+        val obj = Object(key)
+        return objects.getOrPut(obj.key) { obj }
+    }
+
+    /**
+     * Get and return the [Object] corresponding to the given identification, if it exists.
+     *
+     * @param adapterType The adapter type of the object
+     * @param objectType The type of the object
+     * @param name The name of the object
+     * @param identifiers An optional list of [Identifiers][Identifier] for the object
+     * @return The [Object] with the given [Key], or null if an [Object] with the given
+     * [Key] is not in the [CollectResult]
+     */
+    @JvmOverloads
+    fun getObject(
+        adapterType: String,
+        objectType: String,
+        name: String,
+        identifiers: List<Identifier> = emptyList(),
+    ): Object? {
+        val key = Key(adapterType, objectType, name, identifiers)
+        return getObject(key)
+    }
+
+    /**
+     * Get and return the [Object] corresponding to the given [Key], if it exists.
+     *
+     * @param key The object key to search for
+     * @return The [Object] with the given [Key], or null if an [Object] with the given
+     * [Key] is not in the [CollectResult]
+     */
+    fun getObject(
+        key: Key,
+    ): Object? {
+        return objects[key]
+    }
+
+    /**
+     * Returns all [Objects][Object] in this [CollectResult].
+     * @return The [List] of [Objects][Object]
+     */
+    fun getObjects(): List<Object> = objects.values.toList()
+
+    /**
+     * Returns all [Objects][Object] with the given type.
+     * @param objectType The [object type][Key.objectType] to match
+     * @return A [List] of [Objects][Object] matching the [objectType]
+     */
+    fun getObjectsByType(objectType: String) =
+        objects.values.filter { obj ->
+            obj.objectType == objectType
+        }
+
+    /**
+     * Returns all [Objects][Object] with the given adapter type and object type.
+     * @param adapterType The [adapter type][Key.adapterType] to match
+     * @param objectType The [object type][Key.objectType] to match
+     * @return A [List] of [Objects][Object] matching the [adapterType] and [objectType]
+     */
+    fun getObjectsByType(adapterType: String, objectType: String) =
+        objects.values.filter { obj ->
+            obj.adapterType == adapterType && obj.objectType == objectType
+        }
+
+    /**
+     * Returns all [Objects][Object] with the given adapter type.
+     * @param adapterType The [adapter type][Key.adapterType] to match
+     * @return A [List] of [Objects][Object] matching the [adapterType] and [objectType]
+     */
+    fun getObjectsByAdapterType(adapterType: String) =
+        objects.values.filter { obj ->
+            obj.adapterType == adapterType
+        }
+
+    /**
+     * Adds the given [Object] to the [CollectResult] and returns it.
+     *
+     * A different [Object] with the same key cannot already exist in the [CollectResult].
+     * If it does, an [ObjectKeyAlreadyExistsException] will be thrown.
+     *
+     * @param obj The [Object] to add to the [CollectResult].
+     * @return The object.
+     * @throws ObjectKeyAlreadyExistsException: If a different [Object] with the same [Key]
+     * already exists in the [CollectResult].
+     */
+    fun addObject(obj: Object): Object {
+        val o = objects.getOrPut(obj.key) { obj }
+        if (o === obj)
+            return o
+        throw ObjectKeyAlreadyExistsException(obj.key)
+    }
+
+    /**
+     * Adds the given [Objects][Object] to the [CollectResult].
+     *
+     * A different [Object] with the same key cannot already exist in the [CollectResult].
+     * If it does, an [ObjectKeyAlreadyExistsException] will be thrown. All [Objects][Object]
+     * will attempt to add to the [CollectResult].
+     *
+     * @param objects A [Collection] of [Objects][Object] to add to the [CollectResult].
+     * @throws ObjectKeyAlreadyExistsException: If any [Objects][Object] with the same [Key]
+     * already exists in the [CollectResult].
+     */
+    fun addObjects(objects: Iterable<Object>) {
+        val failed = mutableListOf<Key>()
+        for (obj in objects) {
+            try {
+                addObject(obj)
+            } catch (_: ObjectKeyAlreadyExistsException) {
+                failed.add(obj.key)
+            }
+        }
+        if (failed.isNotEmpty()) {
+            throw ObjectKeyAlreadyExistsException(failed)
+        }
+    }
+
+    /**
+     * @return a JSON representation of this [CollectResult] in the format required by Aria
+     * Operations. The representation includes all *internal* [Objects][Object] (including the object's
+     * [Events][Event], [Properties][Property], and [Metrics][Metric]) in the [CollectResult], plus
+     * any *external* [Objects][Object] that have added content.
+     * Relationships are returned following the [updateRelationships] flag
+     * (See [RelationshipUpdateModes]).
+     *
+     */
+    val json: JsonObject
+        get() {
+            val result = mutableMapOf<String, JsonElement>()
+            if (errorMessage != null) {
+                result["errorMessage"] = JsonPrimitive(errorMessage)
+            } else {
+                val relationshipUpdates: Collection<Object> =
+                    when (updateRelationships) {
+                        RelationshipUpdateModes.NONE -> emptyList()
+                        RelationshipUpdateModes.ALL -> objects.values
+                        RelationshipUpdateModes.PER_OBJECT -> objects.values.filter { it.hasUpdatedChildren }
+                        RelationshipUpdateModes.AUTO -> if (objects.values.any { it.hasUpdatedChildren }) objects.values else emptyList()
+                    }
+                result["result"] =
+                    Json.encodeToJsonElement(objects.values
+                        .filter { obj -> !objectIsExternal(obj) or obj.hasContent() })
+                result["relationships"] =
+                    Json.encodeToJsonElement(relationshipUpdates.map { obj ->
+                        mapOf(
+                            "parent" to Json.encodeToJsonElement(obj.key),
+                            "children" to Json.encodeToJsonElement(obj.getChildren())
+                        )
+                    })
+                result["nonExistingObjects"] = JsonArray(listOf())
+            }
+            return JsonObject(result)
+        }
+
+    /**
+     * Opens the output pipe and sends results directly back to the server
+     * This method can only be called once per collection.
+     * @param outputPipe The path to the output pipe.
+     */
+    fun sendResults(outputPipe: String = Pipes.output) {
+        writeToPipe(json, outputPipe)
+    }
+}

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/definition/AdapterDefinition.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/definition/AdapterDefinition.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.aria.operations.definition
+
+class AdapterDefinition(val adapterType: String) {
+    // Placeholder for use in CollectResult
+}

--- a/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/CollectResultTest.java
+++ b/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/CollectResultTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.aria.operations;
+
+import kotlinx.serialization.json.JsonObject;
+import kotlinx.serialization.json.JsonPrimitive;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CollectResultTest {
+    Key simpleObjectKey1 = new Key("adapter", "object", "name");
+    Key simpleObjectKey2 = new Key("adapter", "object", "name2");
+    Key simpleNewObjectKey = new Key("adapter", "newObject", "name3", List.of(new Identifier("key", "value")));
+    Key externalKey = new Key("externalAdapter", "object", "name4");
+
+    CollectResult result;
+    Object obj1;
+    Object obj2;
+    Object obj3;
+    Object obj4;
+
+    @BeforeEach
+    public void setup() {
+        result = new CollectResult();
+        obj1 = new Object(simpleObjectKey1);
+        obj2 = new Object(simpleObjectKey2);
+        obj3 = new Object(simpleNewObjectKey);
+        obj4 = new Object(externalKey);
+    }
+
+    @Test
+    public void success() {
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
+    public void fail() {
+        result.withError("Failed test");
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    public void failJson() {
+        result.withError("Failed test");
+        JsonObject json = (JsonObject) result.getJson();
+        assertEquals("Failed test", ((JsonPrimitive) Objects.requireNonNull(json.get("errorMessage"))).getContent());
+    }
+
+    @Test
+    public void getOrCreateObject() {
+        assertEquals(0, result.getObjects().size());
+        Object obj = result.getOrCreateObject(simpleObjectKey1);
+        assertEquals(1, result.getObjects().size());
+        Object testObj = result.getOrCreateObject(simpleObjectKey1);
+        assertEquals(1, result.getObjects().size());
+        assertSame(obj, testObj);
+    }
+
+    @Test
+    public void GetOrCreateObject2() {
+        assertEquals(0, result.getObjects().size());
+        Object obj = result.getOrCreateObject("adapter", "object", "name");
+        assertEquals(1, result.getObjects().size());
+        Object testObj = result.getOrCreateObject(simpleObjectKey1);
+        assertEquals(1, result.getObjects().size());
+        assertSame(obj, testObj);
+    }
+
+    @Test
+    public void GetOrCreateObject3() {
+        assertEquals(0, result.getObjects().size());
+        Object obj = result.getOrCreateObject(simpleObjectKey1);
+        assertEquals(1, result.getObjects().size());
+        Object testObj = result.getOrCreateObject("adapter", "object", "name");
+        assertEquals(1, result.getObjects().size());
+        assertSame(obj, testObj);
+    }
+
+    @Test
+    public void GetOrCreateObject4() {
+        assertEquals(0, result.getObjects().size());
+        Object obj = result.getOrCreateObject("adapter", "newObject", "name3", List.of(new Identifier("key", "value")));
+        assertEquals(1, result.getObjects().size());
+        Object testObj = result.getOrCreateObject("adapter", "newObject", "name3", List.of(new Identifier("key", "value")));
+        assertEquals(1, result.getObjects().size());
+        assertSame(obj, testObj);
+    }
+
+    @Test
+    public void GetOrCreateObject5() {
+        assertEquals(0, result.getObjects().size());
+        Object obj = result.getOrCreateObject("adapter", "newObject", "name3", List.of(new Identifier("key", "value")));
+        assertEquals(1, result.getObjects().size());
+        Object testObj = result.getOrCreateObject(simpleNewObjectKey);
+        assertEquals(1, result.getObjects().size());
+        assertSame(obj, testObj);
+    }
+
+    @Test
+    public void getObject() {
+        assertEquals(0, result.getObjects().size());
+        Object obj = result.getObject("adapter", "object", "name");
+        assertNull(obj);
+        assertEquals(0, result.getObjects().size());
+    }
+
+    @Test
+    public void getObject2() {
+        assertEquals(0, result.getObjects().size());
+        Object obj = result.getObject("adapter", "newObject", "name3", List.of(new Identifier("key", "value")));
+        assertNull(obj);
+        assertEquals(0, result.getObjects().size());
+    }
+
+    @Test
+    public void getObject3() {
+        assertEquals(0, result.getObjects().size());
+        Object obj = result.getObject(simpleObjectKey1);
+        assertNull(obj);
+        assertEquals(0, result.getObjects().size());
+    }
+
+    @Test
+    public void getObject4() {
+        result.addObject(obj1);
+        Object testObj = result.getObject("adapter", "object", "name");
+        assertSame(obj1, testObj);
+    }
+
+    @Test
+    public void getObject5() {
+        result.addObject(obj3);
+        Object testObj = result.getObject("adapter", "newObject", "name3", List.of(new Identifier("key", "value")));
+        assertSame(obj3, testObj);
+    }
+
+    @Test
+    public void getObject6() {
+        CollectResult result = new CollectResult();
+        result.addObject(obj1);
+        Object testObj = result.getObject(simpleObjectKey1);
+        assertSame(obj1, testObj);
+    }
+
+
+    @Test
+    public void getObjectsByType1() {
+        result.addObjects(List.of(obj1, obj2, obj3, obj4));
+
+        List<Object> objects= result.getObjectsByType("object");
+        assertEquals(3, objects.size());
+        assertTrue(objects.containsAll(List.of(obj1, obj2, obj4)));
+    }
+
+    @Test
+    public void getObjectsByType2() {
+        result.addObjects(List.of(obj1, obj2, obj3, obj4));
+
+        List<Object> objects= result.getObjectsByType("adapter", "object");
+        assertEquals(2, objects.size());
+        assertTrue(objects.containsAll(List.of(obj1, obj2)));
+    }
+
+    @Test
+    public void getObjectsByAdapterType() {
+        result.addObjects(List.of(obj1, obj2, obj3, obj4));
+
+        List<Object> objects= result.getObjectsByAdapterType("adapter");
+        assertEquals(3, objects.size());
+        assertTrue(objects.containsAll(List.of(obj1, obj2, obj3)));
+    }
+
+    @Test
+    public void addObject1() {
+        assertEquals(0, result.getObjects().size());
+        result.addObject(obj1);
+        assertEquals(1, result.getObjects().size());
+    }
+
+    @Test
+    public void addObject2() {
+        assertEquals(0, result.getObjects().size());
+        result.addObject(obj1);
+        assertEquals(1, result.getObjects().size());
+        // Adding the *same* object twice is OK
+        result.addObject(obj1);
+        assertEquals(1, result.getObjects().size());
+    }
+
+    @Test
+    public void addObject3() {
+        assertEquals(0, result.getObjects().size());
+        result.addObject(obj1);
+        assertEquals(1, result.getObjects().size());
+        assertThrows(ObjectKeyAlreadyExistsException.class, () -> {
+            // Adding *different* objects with the same key is not OK
+            result.addObject(new Object(obj1.getKey()));
+        });
+        assertEquals(1, result.getObjects().size());
+    }
+
+    @Test
+    public void addObjects1() {
+        assertEquals(0, result.getObjects().size());
+        result.addObjects(List.of(obj1, obj2, obj3, obj4));
+        assertEquals(4, result.getObjects().size());
+    }
+
+    @Test
+    public void addObjects2() {
+        assertEquals(0, result.getObjects().size());
+        result.addObjects(List.of(obj1, obj4));
+        assertEquals(2, result.getObjects().size());
+        // Adding the *same* objects twice is OK
+        result.addObjects(List.of(obj1, obj2, obj3, obj4));
+        assertEquals(4, result.getObjects().size());
+    }
+
+    @Test
+    public void addObjects3() {
+        assertEquals(0, result.getObjects().size());
+        result.addObjects(List.of(obj1, obj4));
+        assertEquals(2, result.getObjects().size());
+        assertThrows(ObjectKeyAlreadyExistsException.class, () -> {
+            // Adding *different* objects with the same key is not OK
+            result.addObjects(List.of(new Object(obj1.getKey()), obj2, obj3, new Object(obj4.getKey())));
+        });
+        assertEquals(4, result.getObjects().size());
+    }
+}

--- a/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/EndpointResultTest.java
+++ b/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/EndpointResultTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.aria.operations;
+
+import kotlinx.serialization.json.*;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EndpointResultTest {
+    @Test
+    public void emptyJson() {
+        EndpointResult result = new EndpointResult();
+        assertEquals(new JsonObject(new HashMap<>()), result.getJson());
+    }
+
+    @Test
+    public void withEndpoint() {
+        EndpointResult result = new EndpointResult();
+        result.withEndpoint("endpoint");
+        assertEquals(
+                new JsonObject(
+                        Map.of(
+                                "endpointUrls",
+                                new JsonArray(List.of(
+                                        JsonElementKt.JsonPrimitive("endpoint")
+                                ))
+                        )
+                ),
+                result.getJson()
+        );
+    }
+
+    @Test
+    public void withMultipleEndpoint() {
+        EndpointResult result = new EndpointResult();
+        result.withEndpoint("endpoint");
+        result.withEndpoint("endpoint2");
+        result.withEndpoint("endpoint3");
+        assertEquals(
+                new JsonObject(
+                        Map.of(
+                                "endpointUrls",
+                                new JsonArray(List.of(
+                                        JsonElementKt.JsonPrimitive("endpoint"),
+                                        JsonElementKt.JsonPrimitive("endpoint2"),
+                                        JsonElementKt.JsonPrimitive("endpoint3")
+                                ))
+                        )
+                ),
+                result.getJson()
+        );
+    }
+}

--- a/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/TestResultTest.java
+++ b/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/TestResultTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.aria.operations;
+
+import kotlinx.serialization.json.*;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestResultTest {
+
+    @Test
+    public void success() {
+        TestResult result = new TestResult();
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
+    public void fail() {
+        TestResult result = new TestResult();
+        result.withError("Failed test");
+        assertFalse(result.isSuccess());
+    }
+
+    @Test
+    public void successJson() {
+        TestResult result = new TestResult();
+        assertEquals(new JsonObject(new HashMap<>()), result.getJson());
+    }
+
+    @Test
+    public void failJson() {
+        TestResult result = new TestResult();
+        result.withError("Failed test");
+        JsonObject json = (JsonObject) result.getJson();
+        assertEquals("Failed test", ((JsonPrimitive) Objects.requireNonNull(json.get("errorMessage"))).getContent());
+
+    }
+}


### PR DESCRIPTION
Adds TestResult, EndpointResult, and CollectResult classes
Adds tests for above classes
Adds placeholder classes for PipeUtils and AdapterDefinition for use in above classes
Adds additional convenience constructor for the `Object` class

TODO: The Json serialization for `CollectResult` is not tested yet. This will likely be a separate test suite, and will require some effort to ensure all options/paths are exercised/tested.