### PR TITLE
Adds Adapter Logger setup functionality

### DIFF
--- a/lib/java/AdapterLibrary/build.gradle.kts
+++ b/lib/java/AdapterLibrary/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
+    api("org.apache.logging.log4j:log4j-core:2.20.0")
+    api("org.apache.logging.log4j:log4j-api:2.20.0")
 }
 
 tasks.test {

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterLogger.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterLogger.kt
@@ -61,7 +61,18 @@ internal fun setupLogging(
     filePath: String,
 ) {
 
-    val pattern = "%d [%t] %-5level: %msg%n%throwable"
+    // %d - date and time
+    // %t - thread name
+    // %-5level - logging level
+    // %c - logger name
+    // %msg - logger message
+    // %n - newline
+    // %throwable - stacktrace, if applicable
+    // More information:
+    //  https://logging.apache.org/log4j/log4j-2.1/manual/layouts.html#PatternLayout
+    // Example:
+    //  2023-08-25 14:22:39,952 [Test worker] INFO  com.vmware.aria.operations.AdapterLogger: message
+    val pattern = "%d [%t] %-5level %c: %msg%n%throwable"
 
     // Trigger a log rollover on startup and if the file exceeds 'maxSize' bytes
     val triggeringPolicy = CompositeTriggeringPolicy.createPolicy(

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterLogger.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterLogger.kt
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+@file:JvmName("AdapterLogger")
+
+package com.vmware.aria.operations
+
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.appender.RollingFileAppender
+import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy
+import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy
+import org.apache.logging.log4j.core.appender.rolling.OnStartupTriggeringPolicy
+import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy
+import org.apache.logging.log4j.core.config.Configurator
+import org.apache.logging.log4j.core.layout.PatternLayout
+import org.apache.logging.log4j.util.StackLocatorUtil
+import java.io.File
+import kotlin.io.path.Path
+
+
+/**
+ * Sets up logging using the given parameters
+ *
+ * @param filename The name of the file to log to.
+ * @param backupFileCount The total number of backup files to retain. Defaults to 5.
+ * @param maxSize The maximum size in bytes of each file before the file
+ *  automatically rotates to a new one. Defaults to '0', which will
+ *  do no automatic rotation. May require calling the 'rotate()' function
+ *  manually to ensure logs do not become too large.
+ */
+@JvmOverloads
+fun setupLogging(
+    filename: String,
+    backupFileCount: Int = 5,
+    maxSize: Long = 0L,
+) {
+    // '/var/log' is the location of logs in the Adapter Container, and shouldn't
+    // be changed.
+    setupLogging(filename, backupFileCount, maxSize, "/var/log")
+}
+
+/**
+ * Internal constructor for testing purposes that sets up logging using the given parameters
+ *
+ * @param filename The name of the file to log to.
+ * @param backupFileCount The total number of backup files to retain. Defaults to 5.
+ * @param maxSize The maximum size in bytes of each file before the file
+ *  automatically rotates to a new one. Defaults to '0', which will
+ *  do no automatic rotation. Requires calling the 'rotate()' function
+ *  manually to ensure logs do not become too large.
+ *  @param filePath The location where the config file and logs reside in.
+ */
+internal fun setupLogging(
+    filename: String,
+    backupFileCount: Int,
+    maxSize: Long,
+    filePath: String,
+) {
+
+    val pattern = "%d [%t] %-5level: %msg%n%throwable"
+
+    // Trigger a log rollover on startup and if the file exceeds 'maxSize' bytes
+    val triggeringPolicy = CompositeTriggeringPolicy.createPolicy(
+        OnStartupTriggeringPolicy.createPolicy(1),
+        if (maxSize > 0) {
+            SizeBasedTriggeringPolicy.createPolicy("$maxSize")
+        } else {
+            SizeBasedTriggeringPolicy.createPolicy(null)
+        }
+    )
+
+    val rolloverStrategy = DefaultRolloverStrategy.newBuilder()
+        .withMax("$backupFileCount")
+        // By default, the rollover strategy counts 'up', so that once the main log file
+        // rolls over, it goes to the highest available number and all other backup logs
+        // shift down. VMware Aria Ops logs are not set up this way, and neither is
+        // Python's logging system. Setting fileIndex to 'min' changes the behavior to
+        // match, where when the main log file rolls over, it goes to the minimum number
+        // (e.g., *.log.1) and all other backup logs shift up.
+        .withFileIndex("min")
+        .build()
+
+    val patternLayout = PatternLayout.newBuilder()
+        .withPattern(pattern)
+        .build()
+
+    val rollingFileAppender = RollingFileAppender.newBuilder()
+        .setName("Rolling Adapter File Appender")
+        .setLayout(patternLayout)
+        .withFileName("$filePath/$filename.log")
+        .withFilePattern("$filePath/$filename.log.%i")
+        .withPolicy(triggeringPolicy)
+        .withStrategy(rolloverStrategy)
+        .build()
+    rollingFileAppender.start()
+
+    val context = LogManager.getContext(false) as LoggerContext
+    val level = getDefaultLogLevel(filePath)
+    val filter = context.configuration.rootLogger.filter
+
+    // There are two different levels here - the level of the root logger, and the level
+    // of the appender. The level of the root logger is the level that all new loggers
+    // will have if they haven't explicitly been overridden. The level of the appender
+    // acts as a filter on all loggers that are using the appender. So if the appender
+    // is set to INFO, it will never emit a DEBUG log, even if the logger itself
+    // is set to DEBUG level. For this reason, we're setting the appender to the 'ALL'
+    // level
+    context.configuration.rootLogger.level = level
+    context.configuration.rootLogger.addAppender(rollingFileAppender, Level.ALL, filter);
+    context.configuration.addAppender(rollingFileAppender)
+    setLogLevels(filePath)
+    context.updateLoggers();
+}
+
+/**
+ * Returns a Logger with the name of the calling class. This is identical to calling Log4j's
+ * LogManager.getLogger() method. It is reimplemented here for convenience.
+ *
+ * @return The Logger for the calling class.
+ * @throws UnsupportedOperationException if the calling class cannot be determined.
+ */
+fun getLogger(): Logger =
+    LogManager.getLogger(StackLocatorUtil.getCallerClass(2))
+
+/**
+ * Returns a Logger with the name of the calling class. This is identical to calling Log4j's
+ * LogManager.getLogger(name) method. It is reimplemented here for convenience.
+ *
+ * @param name the name of the Logger.
+ * @return The Logger with the given name.
+ */
+fun getLogger(name: String): Logger =
+    LogManager.getLogger(name)
+
+/**
+ * Manually trigger the log files to rotate.
+ */
+fun rotate() {
+    val logger = LogManager.getLogger() as org.apache.logging.log4j.core.Logger
+    // Iterate through each rolling appender and perform a rollover.
+    // 'toSet' is used to ensure we don't roll over any appender twice
+    logger.appenders.values.toSet().forEach { appender ->
+        if (appender is RollingFileAppender) {
+            appender.manager.rollover()
+        }
+    }
+}
+
+private fun getDefaultLogLevel(
+    filePath: String,
+    defaultLevel: Level = Level.INFO,
+): Level {
+    val config = PyCFG()
+    val configFile = Path(filePath).resolve("loglevels.cfg").toFile()
+    config.read(configFile)
+    var modified = false
+    if (!config.defaults().containsKey("adapter")) {
+        modified = true
+        config.setDefault("adapter", defaultLevel.name())
+    }
+    if (!config.hasSection("adapter")) {
+        modified = true
+        config.addSection("adapter")
+        config.set("adapter", "main", defaultLevel.name())
+    }
+    if (modified) {
+        config.write(configFile)
+    }
+    return try {
+        Level.getLevel(
+            config.defaults().getOrDefault("adapter", defaultLevel.name())
+        )
+    } catch (_: IllegalArgumentException) {
+        defaultLevel
+    }
+}
+
+private fun setLogLevels(filePath: String) {
+    val config = PyCFG()
+    val configFile = Path(filePath).resolve("loglevels.cfg").toFile()
+    config.read(configFile)
+    config.section("adapter").forEach { (name, level) ->
+        Configurator.setLevel(name, level)
+    }
+}
+
+/**
+ * Simple class to read and write Python cfg (ini) files
+ */
+internal class PyCFG {
+    private val config = LinkedHashMap<String, LinkedHashMap<String, String>>()
+
+    fun read(file: File) {
+        var currentSection = config.getOrPut(DEFAULT) { LinkedHashMap() }
+        if (!file.exists()) {
+            return
+        }
+        file.readLines().map { it.trim() }.forEach { line ->
+            if (line.startsWith("[") && line.endsWith("]")) {
+                val section = line.drop(1).dropLast(1)
+                currentSection = config.getOrPut(section) { LinkedHashMap() }
+            } else if (line.startsWith(";") || line.startsWith("#") || line.isBlank()) {
+                // comment or empty line; ignore
+                return@forEach
+            } else if (line.contains("=")) {
+                // value
+                val key = line.substringBefore("=").trim()
+                val value = line.substringAfter("=").trim()
+                currentSection[key] = value
+            } else {
+                // ignore?
+            }
+        }
+    }
+
+    fun write(file: File) {
+        if (!file.exists()) {
+            file.createNewFile()
+        }
+        file.printWriter().use { ini ->
+            config.forEach { (section, sectionContents) ->
+                ini.println("[$section]")
+                sectionContents.forEach { (key, value) ->
+                    ini.println("$key = $value")
+                }
+                ini.println()
+            }
+        }
+    }
+
+    fun hasSection(section: String) = config.containsKey(section)
+    fun addSection(section: String) {
+        config.getOrPut(section) { LinkedHashMap() }
+    }
+
+    fun set(section: String, key: String, value: String) {
+        config[section]?.set(key, value)
+    }
+
+    fun setDefault(key: String, value: String) {
+        config[DEFAULT]?.set(key, value)
+    }
+
+    fun section(section: String): Map<String, String> = config[section] ?: mapOf()
+    fun defaults(): Map<String, String> = config.getOrPut(DEFAULT) { LinkedHashMap() }
+
+    fun get(section: String, key: String, default: String? = null) =
+        section(section)[key] ?: defaults()[key] ?: default
+
+    companion object {
+        private const val DEFAULT = "DEFAULT"
+    }
+}

--- a/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/LoggerTest.java
+++ b/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/LoggerTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.vmware.aria.operations;
+
+import org.apache.logging.log4j.*;
+import org.apache.logging.log4j.core.config.*;
+import org.junit.jupiter.api.*;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LoggerTest {
+    static String FILENAME = "loggerTest";
+    static String PATH;
+
+    static {
+        try {
+            PATH = Files.createTempDirectory("tmpDirPrefix").toFile().getAbsolutePath();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    ;
+    static File CONFIG_FILE = new File(PATH + "/loglevels.cfg");
+    static File LOG_0 = new File(PATH + "/" + FILENAME + ".log");
+    static File LOG_1 = new File(PATH + "/" + FILENAME + ".log.1");
+    static File LOG_2 = new File(PATH + "/" + FILENAME + ".log.2");
+    static File LOG_3 = new File(PATH + "/" + FILENAME + ".log.3");
+
+    @AfterEach
+    public void reset() {
+        // Removes all files in temp directory, rather than just what we are expecting to be present
+        List<File> files = Arrays.stream(Objects.requireNonNull(new File(PATH).listFiles())).toList();
+        for (File file : files) {
+            file.delete();
+        }
+
+        // Re-initialize log4j2. Weird things happen if this isn't done (or done
+        // incompletely) between tests
+        Configurator.initialize(new DefaultConfiguration());
+        Configurator.reconfigure();
+    }
+
+    @AfterAll
+    public static void removeTempDir() {
+        new File(PATH).delete();
+    }
+
+
+    @Test
+    public void setupLoggingTest() {
+        AdapterLogger.setupLogging(FILENAME, 5, 0, PATH);
+        Logger logger = AdapterLogger.getLogger();
+        logger.debug("setupLoggingTest");
+        logger.info("setupLoggingTest");
+        logger.warn("setupLoggingTest");
+        logger.error("setupLoggingTest");
+        logger.fatal("setupLoggingTest");
+
+        // Default level is INFO
+        assertFalse(fileContains(LOG_0, "DEBUG"));
+        assertTrue(fileContains(LOG_0, "INFO"));
+        assertTrue(fileContains(LOG_0, "WARN"));
+        assertTrue(fileContains(LOG_0, "ERROR"));
+        assertTrue(fileContains(LOG_0, "FATAL"));
+    }
+
+    @Test
+    public void rotateTest() {
+        AdapterLogger.setupLogging(FILENAME, 5, 0, PATH);
+        Logger logger = AdapterLogger.getLogger();
+        logger.info("rotateTest1");
+        AdapterLogger.rotate();
+        logger.info("rotateTest2");
+
+        assertTrue(fileContains(LOG_0, "rotateTest2"));
+        assertTrue(fileContains(LOG_1, "rotateTest1"));
+        assertFalse(LOG_2.exists());
+    }
+
+    @Test
+    public void rotateMaxBackups() {
+        AdapterLogger.setupLogging(FILENAME, 2, 0, PATH);
+        Logger logger = AdapterLogger.getLogger();
+        logger.info("rotateTest1");
+        AdapterLogger.rotate();
+        logger.info("rotateTest2");
+        AdapterLogger.rotate();
+        logger.info("rotateTest3");
+        AdapterLogger.rotate();
+        logger.info("rotateTest4");
+
+        assertTrue(fileContains(LOG_0, "rotateTest4"));
+        assertTrue(fileContains(LOG_1, "rotateTest3"));
+        assertTrue(fileContains(LOG_2, "rotateTest2"));
+        assertFalse(LOG_3.exists());
+    }
+
+    @Test
+    public void rotateMaxFileSize() {
+        AdapterLogger.setupLogging(FILENAME, 2, 100, PATH);
+        Logger logger = AdapterLogger.getLogger();
+        String message = "A long message that will reach the max size limit of 100 bytes";
+        logger.info(message);
+        logger.info(message);
+        assertTrue(fileContains(LOG_0, message));
+        assertTrue(fileContains(LOG_1, message));
+        assertFalse(LOG_2.exists());
+    }
+
+    @Test
+    public void readConfigTest() {
+        PyCFG cfg = new PyCFG();
+        cfg.addSection("adapter");
+        cfg.set("adapter", "test", Level.FATAL.name());
+        cfg.write(CONFIG_FILE);
+
+        AdapterLogger.setupLogging(FILENAME, 5, 0, PATH);
+        Logger defaultLogger = AdapterLogger.getLogger();
+        Logger testLogger = AdapterLogger.getLogger("test");
+
+        defaultLogger.info("DEFAULT_LOGGER_INFO");
+        testLogger.info("TEST_LOGGER_INFO");
+        testLogger.fatal("TEST_LOGGER_FATAL");
+
+        assertTrue(fileContains(LOG_0, "DEFAULT_LOGGER_INFO"));
+        assertFalse(fileContains(LOG_0, "TEST_LOGGER_INFO"));
+        assertTrue(fileContains(LOG_0, "TEST_LOGGER_FATAL"));
+    }
+
+    @Test
+    public void readConfigTest2() {
+        PyCFG cfg = new PyCFG();
+        cfg.addSection("adapter");
+        // Ensure that we can set to a lower level than the root logger. This can be a
+        // problem if the appender log level isn't set correctly.
+        cfg.set("adapter", "test", Level.DEBUG.name());
+        cfg.write(CONFIG_FILE);
+
+        AdapterLogger.setupLogging(FILENAME, 5, 0, PATH);
+        Logger defaultLogger = AdapterLogger.getLogger();
+        Logger testLogger = AdapterLogger.getLogger("test");
+
+        defaultLogger.debug("DEFAULT_LOGGER_DEBUG");
+        defaultLogger.info("DEFAULT_LOGGER_INFO");
+        testLogger.debug("TEST_LOGGER_DEBUG");
+        testLogger.info("TEST_LOGGER_INFO");
+
+        assertFalse(fileContains(LOG_0, "DEFAULT_LOGGER_DEBUG"));
+        assertTrue(fileContains(LOG_0, "DEFAULT_LOGGER_INFO"));
+        assertTrue(fileContains(LOG_0, "TEST_LOGGER_DEBUG"));
+        assertTrue(fileContains(LOG_0, "TEST_LOGGER_INFO"));
+    }
+
+    public boolean fileContains(File file, String expectedContents) {
+        try {
+            if (!file.exists()) {
+                return false;
+            }
+            String contents = String.join(System.lineSeparator(), Files.readAllLines(file.toPath()));
+            return contents.contains(expectedContents);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/LoggerTest.java
+++ b/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/LoggerTest.java
@@ -22,7 +22,8 @@ public class LoggerTest {
 
     static {
         try {
-            PATH = Files.createTempDirectory("tmpDirPrefix").toFile().getAbsolutePath();
+            PATH = Files.createTempDirectory("JavaAdapterLibraryLoggerTest").toFile().getAbsolutePath();
+            new File(PATH).deleteOnExit();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -47,11 +48,6 @@ public class LoggerTest {
         // incompletely) between tests
         Configurator.initialize(new DefaultConfiguration());
         Configurator.reconfigure();
-    }
-
-    @AfterAll
-    public static void removeTempDir() {
-        new File(PATH).delete();
     }
 
 


### PR DESCRIPTION
* Adds `AdapterLogger` class that simplifies setting up and creating a logger in Java adapter code
* Reads a simple configuration from the same `loglevels.cfg` file as the server and Python adapters.