### PR TITLE
Adds AdapterInstance class to Java Adapter Library

### DIFF
--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterInstance.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterInstance.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.vmware.aria.operations
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+@Serializable
+data class CredentialField(val key: String, val value: String)
+
+@Serializable
+class Credential(
+    /**
+     * Get the type (key) of credential. This is useful if an adapter supports multiple
+     * types of credentials.
+     *
+     * @return The type of the credential used by this adapter instance, or null if the
+     * adapter instance does not have a credential.
+     */
+    @SerialName("credential_key") val type: String?,
+    @SerialName("credential_fields") private val fields: List<CredentialField>,
+): Map<String, String> by fields.associate({ field -> Pair(field.key, field.value) })
+
+/**
+ * Class that represents a list of validated SSL certificates that have been verified
+ * automatically by a CA or manually by the user.
+ */
+@Serializable
+class Certificates(private val certificates: List<String>) :
+    List<String> by certificates
+
+/**
+ * Class that describes a time window. In some cases, it is useful to have a start and end time
+ * for collection. The CollectionWindow's [startTime] and [endTime] will be modified each collection
+ * such that each collection's [endTime] will be the next collection's [startTime]. Thus, the window
+ * can be treated as either the interval `(startTime, endTime]` or `[startTime, endTime)`, so long
+ * as each collection uses the same convention, there will be no overlaps or missing times. (Note
+ * that restarting the adapter instance will reset the time window. In general, this will cause
+ * overlap and/or missing times when restarts occur for any reason)
+ */
+@Serializable
+data class CollectionWindow(
+    /**
+     * The start of the window. On the first collection, this will be set to `0`.
+     */
+    @SerialName("start_time") val startTime: Long,
+    /**
+     * The end of the window
+     */
+    @SerialName("end_time") val endTime: Long,
+)
+
+class AdapterInstance(json: JsonObject) : Object(getKey(json)) {
+    /**
+     * Gets information about the credential (if it exists) for this Adapter Instance
+     */
+    val credential: Credential
+
+    /**
+     * Gets an authenticated [Suite API Client][SuiteApiClient].
+     */
+    val suiteApiClient: SuiteApiClient
+
+    /**
+     * Gets the list of SSL Certificates that have been verified automatically by a CA
+     * or manually by the user.
+     */
+    val certificates: Certificates
+
+    /**
+     * Gets the current collection number, starting from 0.
+     */
+    val collectionNumber: Int
+
+    /**
+     * Gets the current collection window.
+     */
+    val collectionWindow: CollectionWindow
+
+    init {
+        credential = json["credential_config"]?.let {
+            Json.decodeFromJsonElement(it)
+        } ?: Credential(null, emptyList())
+
+        suiteApiClient = json["cluster_connection_info"]?.let {
+            Json.decodeFromJsonElement(it)
+        } ?: SuiteApiClient("", "", "")
+
+        certificates = json["certificate_config"]?.let {
+            Json.decodeFromJsonElement(it)
+        } ?: Certificates(emptyList())
+
+        collectionNumber = json["collection_number"]?.jsonPrimitive?.int ?: 0
+        collectionWindow = json["collection_window"]?.let {
+            Json.decodeFromJsonElement(it)
+        } ?: CollectionWindow(0, System.currentTimeMillis())
+    }
+
+    /**
+     * @return The type (key) of the credential, or `null` if this Adapter Instance does
+     * not have a credential.
+     */
+    fun getCredentialType(): String? = credential.type
+
+    /**
+     * Retrieve the value of a given credential
+     * @param key Key of the credential field
+     * @return value associated with the credential field, or null if a credential field
+     * with the given key does not exist.
+     */
+    fun getCredentialValue(key: String): String? = credential[key]
+
+    companion object {
+        /**
+         * Create an [AdapterInstance] from the input pipe.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun fromInput(inputFile: String = Pipes.input): AdapterInstance {
+            val json = readFromPipe(inputFile)
+                ?: throw IllegalArgumentException("Cannot read Adapter Instance from input")
+            return AdapterInstance(json.jsonObject)
+        }
+
+
+        private fun getKey(json: JsonObject): Key {
+            return json["adapter_key"]?.jsonObject?.let { adapterKey ->
+                Key(
+                    adapterType = adapterKey["adapter_kind"].toString(),
+                    objectType = adapterKey["object_kind"].toString(),
+                    name = adapterKey["name"].toString(),
+                    identifiers = adapterKey["identifiers"]?.jsonArray?.map { identifier ->
+                        Identifier(
+                            identifier.jsonObject["key"].toString(),
+                            identifier.jsonObject["value"].toString(),
+                            identifier.jsonObject["is_part_of_uniqueness"]?.jsonPrimitive?.boolean
+                                ?: true
+                        )
+                    } ?: listOf()
+                )
+            }
+                ?: throw IllegalArgumentException("Cannot read Adapter Instance Key from input")
+        }
+    }
+}

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/SuiteApiClient.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/SuiteApiClient.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.vmware.aria.operations
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class SuiteApiClient(
+    @SerialName("host_name") val hostname: String,
+    @SerialName("user_name") val username: String,
+    private val password: String,
+) {
+
+}

--- a/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/AdapterInstanceTest.java
+++ b/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/AdapterInstanceTest.java
@@ -1,0 +1,164 @@
+package com.vmware.aria.operations;
+
+import kotlinx.serialization.json.*;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdapterInstanceTest {
+    private JsonArray arr(List<? extends JsonElement> a) {
+        return new JsonArray(a);
+    }
+
+    private JsonObject obj(Map<String, ? extends JsonElement> o) {
+        return new JsonObject(o);
+    }
+
+    private JsonPrimitive str(String s) {
+        return JsonElementKt.JsonPrimitive(s);
+    }
+
+    private JsonPrimitive bool(boolean b) {
+        return JsonElementKt.JsonPrimitive(b);
+    }
+
+    private JsonPrimitive n(Number i) {
+        return JsonElementKt.JsonPrimitive(i);
+    }
+
+    private JsonPrimitive nil() {
+        return JsonElementKt.JsonPrimitive((Boolean) null);
+    }
+
+    JsonObject KEY = obj(Map.of(
+            "name", str("MyAdapterInstanceName"),
+            "adapter_kind", str("MyAdapterKind"),
+            "object_kind", str("MyAdapterKind_AdapterInstance"),
+            "identifiers", arr(List.of(
+                    obj(Map.of(
+                            "key", str("id1"),
+                            "value", str("value1"),
+                            "is_part_of_uniqueness", bool(true)
+                    )),
+                    obj(Map.of(
+                            "key", str("id2"),
+                            "value", str("value2"),
+                            "is_part_of_uniqueness", bool(true)
+                    ))
+            ))
+    ));
+
+    String CREDENTIAL_TYPE = "type1";
+    String FIELD1 = "field1";
+    String FIELD1_VALUE = "value1";
+    String FIELD2 = "field2";
+    String FIELD2_VALUE = "value2";
+    JsonObject CREDENTIAL = obj(Map.of(
+            "credential_key", str(CREDENTIAL_TYPE),
+            "credential_fields", arr(List.of(
+                    obj(Map.of(
+                            "key", str(FIELD1),
+                            "value", str(FIELD1_VALUE)
+                    )),
+                    obj(Map.of(
+                            "key", str(FIELD2),
+                            "value", str(FIELD2_VALUE)
+                    ))
+            ))
+    ));
+
+    JsonObject NULL_CREDENTIAL = obj(Map.of());
+
+    String CERT1 = "Certificate1_ae4c200b34";
+    String CERT2 = "Certificate2_ff7d2c2b65";
+    JsonElement CERTIFICATES = obj(Map.of(
+            "certificates", arr(List.of(
+                    str(CERT1),
+                    str(CERT2)
+            ))
+    ));
+
+    String USERNAME = "user1";
+    String PASSWORD = "P@SSW0RD";
+    String HOSTNAME = "https://host.com";
+    JsonElement CLUSTER_CONNECTION_INFO = obj(Map.of(
+            "user_name", str(USERNAME),
+            "password", str(PASSWORD),
+            "host_name", str(HOSTNAME)
+    ));
+
+    Long START_TIME = 123L;
+    Long END_TIME = 456L;
+    JsonElement WINDOW = obj(Map.of(
+            "start_time", n(START_TIME),
+            "end_time", n(END_TIME)
+    ));
+
+    Integer COLLECTION_NUMBER = 1;
+    JsonObject ADAPTER_INSTANCE1 = obj(Map.of(
+            "adapter_key", KEY,
+            "credential_config", CREDENTIAL,
+            "cluster_connection_info", CLUSTER_CONNECTION_INFO,
+            "certificate_config", CERTIFICATES,
+            "collection_number", n(COLLECTION_NUMBER),
+            "collection_window", WINDOW
+    ));
+
+    @Test
+    public void getCredential() {
+        AdapterInstance ai = new AdapterInstance(ADAPTER_INSTANCE1);
+        assertNotNull(ai.getCredential());
+        assertEquals(CREDENTIAL_TYPE, ai.getCredential().getType());
+        assertEquals(FIELD1_VALUE, ai.getCredential().get(FIELD1));
+        assertEquals(FIELD2_VALUE, ai.getCredential().get(FIELD2));
+        assertNull(ai.getCredential().get("field3"));
+    }
+
+    @Test
+    public void getSuiteApiClient() {
+        AdapterInstance ai = new AdapterInstance(ADAPTER_INSTANCE1);
+        assertNotNull(ai.getSuiteApiClient());
+        assertEquals(HOSTNAME, ai.getSuiteApiClient().getHostname());
+        assertEquals(USERNAME, ai.getSuiteApiClient().getUsername());
+        // Password is private
+    }
+
+    @Test
+    public void getCertificates() {
+        AdapterInstance ai = new AdapterInstance(ADAPTER_INSTANCE1);
+        assertNotNull(ai.getCertificates());
+        assertEquals(2, ai.getCertificates().size());
+        assertEquals(CERT1, ai.getCertificates().get(0));
+        assertEquals(CERT2, ai.getCertificates().get(1));
+    }
+
+    @Test
+    public void getCollectionNumber() {
+        AdapterInstance ai = new AdapterInstance(ADAPTER_INSTANCE1);
+        assertEquals(COLLECTION_NUMBER, ai.getCollectionNumber());
+    }
+
+    @Test
+    public void getCollectionWindow() {
+        AdapterInstance ai = new AdapterInstance(ADAPTER_INSTANCE1);
+        assertNotNull(ai.getCollectionWindow());
+        assertEquals(START_TIME, ai.getCollectionWindow().getStartTime());
+        assertEquals(END_TIME, ai.getCollectionWindow().getEndTime());
+    }
+
+    @Test
+    public void getCredentialType() {
+        AdapterInstance ai = new AdapterInstance(ADAPTER_INSTANCE1);
+        assertEquals(CREDENTIAL_TYPE, ai.getCredentialType());
+    }
+
+    @Test
+    public void getCredentialValue() {
+        AdapterInstance ai = new AdapterInstance(ADAPTER_INSTANCE1);
+        assertEquals(FIELD1_VALUE, ai.getCredentialValue(FIELD1));
+        assertEquals(FIELD2_VALUE, ai.getCredentialValue(FIELD2));
+        assertNull(ai.getCredentialValue("field3"));
+    }
+}


### PR DESCRIPTION
* Deserializes from server requests. Note: The formatting of json keys are different between the server requests and responses. Because of this, we can't deserialize Object Keys using the normal method, we are required to do it manually.
* Initializes Suite API Client. This is not implemented in this PR, but does include a stub so that the code will compile.