### PR TITLE
Bug/285

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 VMware Aria Operations Integration SDK
 --------------------------------------
+## 1.0.1 (09-16-2023)
+* Fix issue where server would repeatedly crash if logging directory was not writable
+  * If user runs mp-init using root, the logs directory's permissions are set to world-wriable
+  * If user runs mp-init as root, mp-init warns that the above will happen
+  * Improves error handling when logs directory is not writable to prevent server crashes
+
 ## 1.0.0 (07/26/2023)
 * Improved documentation site
 * Additional sample and template projects

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -49,7 +49,7 @@ pipx install vmware-aria-operations-integration-sdk
 After the SDK is installed, create a new project, by running `mp-init`. This tool asks a series of questions that guide
 the creation of a new management pack project.
 
-???+ note
+???+ warning
     Running `mp-init` as root is not recommended, as this requires some directories to have escalated permissions.
 
 

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -49,6 +49,9 @@ pipx install vmware-aria-operations-integration-sdk
 After the SDK is installed, create a new project, by running `mp-init`. This tool asks a series of questions that guide
 the creation of a new management pack project.
 
+???+ note
+    Running `mp-init` as root is not recommended, as this requires some directories to have escalated permissions.
+
 
 1. `Enter a directory to create the project in. This is the directory where adapter code, metadata, and content will reside. If the directory doesn't already exist, it will be created. Path:`
 

--- a/docs/references/mp-init.md
+++ b/docs/references/mp-init.md
@@ -11,6 +11,9 @@ an initial project structure and create classifiers that other tools and VMware 
 ## Prerequisites
 * The [VMware Aria Operations Integration SDK](../get_started.md#installation) is installed, with the virtual environment active.
 
+???+ note
+    Running `mp-init` as root is not recommended, as this requires some directories to have escalated permissions.
+
 ## Input
 
 ### Command-line Arguments

--- a/docs/references/mp-init.md
+++ b/docs/references/mp-init.md
@@ -11,7 +11,7 @@ an initial project structure and create classifiers that other tools and VMware 
 ## Prerequisites
 * The [VMware Aria Operations Integration SDK](../get_started.md#installation) is installed, with the virtual environment active.
 
-???+ note
+???+ warning
     Running `mp-init` as root is not recommended, as this requires some directories to have escalated permissions.
 
 ## Input

--- a/images/base-python-adapter/CHANGELOG.md
+++ b/images/base-python-adapter/CHANGELOG.md
@@ -1,5 +1,8 @@
 VMware Aria Operations Integration Base Python Adapter
 ----------------------------------------------
+## 0.12.1 (09-15-2023)
+* Improve logging setup error handling: Ensure that if the logs directory is not writable the Adapter
+  will still run.
 ## 0.12.0 (05-03-2023)
 * Add `schema_version` to adapter definition endpoint to track the schema version used by the Adapter
 * Update Credential and Identifier enum type to support labels and display orders for each enum value

--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 VMware Aria Operations Integration SDK Library
 ----------------------------------------------
+## 0.8.1 (09-15-2023)
+* Improve error handling when log directory is not writable
+
 ## 0.8.0 (07-26-2023)
 * Add py.typed files for typing support in compliance with PEP-561
 

--- a/vmware_aria_operations_integration_sdk/container_versions.json
+++ b/vmware_aria_operations_integration_sdk/container_versions.json
@@ -2,7 +2,7 @@
     "base_image": {
         "language": "Python",
         "path": "base-python-adapter",
-        "version": "0.12.0"
+        "version": "0.12.1"
     },
     "registry_url": "projects.registry.vmware.com/vmware_aria_operations_integration_sdk",
     "secondary_images": [

--- a/vmware_aria_operations_integration_sdk/docker_wrapper.py
+++ b/vmware_aria_operations_integration_sdk/docker_wrapper.py
@@ -285,6 +285,9 @@ def run_image(
     if exposed_port:
         port = exposed_port
 
+    if not os.access(f"{path}/logs", os.W_OK):
+        logger.warn(f"{path}/logs directory is not writable.")
+
     # Docker memory parameters expect a unit ('m' is 'MB'), or the number will be interpreted as bytes
     # vROps sets the swap memory limit to the memory limit + 512MB, so we will also. The swap memory
     # setting is a combination of memory and swap, so this will limit swap space to a max of 512MB regardless

--- a/vmware_aria_operations_integration_sdk/mp_init.py
+++ b/vmware_aria_operations_integration_sdk/mp_init.py
@@ -250,6 +250,20 @@ def main() -> None:
     )
     parser.parse_args()
 
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        if (
+            selection_prompt(
+                "Detected that 'mp-init' is being run as root or using sudo. This is not "
+                "recommended. Continue?",
+                [("no", "No"), ("yes", "Yes")],
+                "If 'mp-init' proceeds as root:\n"
+                " * Some directories will need write permissions by non-root users.\n"
+                " * Elevated permissions will also be required when running 'mp-test' and 'mp-build'\n"
+                " * There may be other unexpected behavior",
+            )
+            == "no"
+        ):
+            exit(0)
     path = ""
     try:
         path = path_prompt(

--- a/vmware_aria_operations_integration_sdk/mp_init.py
+++ b/vmware_aria_operations_integration_sdk/mp_init.py
@@ -177,6 +177,12 @@ def create_project(
 
     project = Project(path)
 
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        # Log directory must be writable by non-root users so that the adapter container
+        # is able to create and write log files.
+        log_dir = mkdir(path, "logs")
+        os.chmod(log_dir, 0o755)
+
     build_content_directory(path)
     conf_dir = mkdir(path, "conf")
     conf_resources_dir = mkdir(conf_dir, "resources")


### PR DESCRIPTION
Fix issue where server would repeatedly crash if logging directory was not writable
  * If user runs mp-init using root, the logs directory's permissions are set to world-wriable
  * If user runs mp-init as root, mp-init warns that the above will happen
  * Improves error handling when logs directory is not writable to prevent server crashes

Resolves #285