### PR TITLE
Add error docker build stack trace to build error

### DIFF
--- a/vmware_aria_operations_integration_sdk/docker_wrapper.py
+++ b/vmware_aria_operations_integration_sdk/docker_wrapper.py
@@ -190,7 +190,9 @@ def build_image(
         for log in error.build_log:
             if "stream" in log:
                 line = log["stream"]
-                if line.strip() != "":
+                if "* Try:" in line:
+                    break
+                elif line.strip() != "":
                     error_message += "\n" + line
 
         raise BuildError(

--- a/vmware_aria_operations_integration_sdk/logging_format.py
+++ b/vmware_aria_operations_integration_sdk/logging_format.py
@@ -25,10 +25,7 @@ class CustomFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> Tuple[str, Optional[str]]:  # type: ignore
         style = self.FORMATS.get(record.levelno)
-
-        if "\x1b" in record.msg:
-            style = "class:ansi_escaped"
-        elif "style" in record.__dict__:
+        if "style" in record.__dict__:
             style = record.__dict__["style"]
 
         formatter = logging.Formatter(self.format_message)

--- a/vmware_aria_operations_integration_sdk/mp_test.py
+++ b/vmware_aria_operations_integration_sdk/mp_test.py
@@ -911,7 +911,7 @@ def main() -> None:
         exit(1)
     except DockerWrapperError as docker_error:
         logger.error("Unable to build container")
-        logger.error(f"{docker_error.message}")
+        logger.error(f"{docker_error.message}", extra={"style": "class:ansi_escaped"})
         logger.error(f"{docker_error.recommendation}")
         exit(1)
     except (ContainerError, APIError) as skd_error:

--- a/vmware_aria_operations_integration_sdk/ui.py
+++ b/vmware_aria_operations_integration_sdk/ui.py
@@ -62,7 +62,6 @@ style = Style.from_dict(
         "warning": "fg:ansiyellow",
         "error": "fg:ansired",
         "critical": "fg:ansired bold",
-        "ansi_escaped": "",
         # Misc messages in UI
         "information": "bg:ansiblue fg:ansiblack",
         "important": "bg:ansidarkred fg:ansiblack",


### PR DESCRIPTION
- Resolves: #255

# Before:
![image](https://github.com/vmware/vmware-aria-operations-integration-sdk/assets/22756465/b00db658-5c52-4f24-b2e9-1e30149c1a6b)

# After:
![image](https://github.com/vmware/vmware-aria-operations-integration-sdk/assets/22756465/2fff5a77-049a-482b-91a8-c24728c38007)

