### PR TITLE
Automatically build documentation for Java Adapter Library

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,8 +28,10 @@ jobs:
     - name: Install Python Adapter Library
       run: pip install -e lib/python/
     - name: Generate Java Adapter Library Documentation
-      run: ./lib/java/AdapterLibrary/gradlew -p lib/java/AdapterLibrary dokkaGfm
-    - run: cp -r lib/java/AdapterLibrary/build/dokka/gfm/* docs/references/java-lib/
+      run: |
+        ./lib/java/AdapterLibrary/gradlew -p lib/java/AdapterLibrary dokkaHtml
+        rm -r docs/references/java-lib/*
+        cp -r lib/java/AdapterLibrary/build/dokka/html/* docs/references/java-lib/
     - name: Deploy MKDocs Site
       run: mkdocs gh-deploy --force --remote-branch github-pages-documentation-test
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,11 +1,5 @@
 name: documentation
-on:
-  push:
-    branches:
-    - main
-  pull_request:
-    branches:
-    - develop
+on: [pull_request]
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,8 @@
 name: documentation
-on: [pull_request]
+on:
+  push:
+    branches:
+    - main
 permissions:
   contents: write
 jobs:
@@ -33,5 +36,5 @@ jobs:
         mkdir -p docs/references/java-lib/
         cp -r lib/java/AdapterLibrary/build/dokka/html/* docs/references/java-lib/
     - name: Deploy MKDocs Site
-      run: mkdocs gh-deploy --force --remote-branch github-pages-documentation-test
+      run: mkdocs gh-deploy --force --remote-branch github-pages-documentation
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - develop
 permissions:
   contents: write
 jobs:
@@ -10,9 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
+    - name: Setup JDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: zulu
+        java-version: '17'
     - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
     - uses: actions/cache@v3
       with:
@@ -20,7 +29,13 @@ jobs:
         path: .cache
         restore-keys: |
           mkdocs-material-
-    - run: pip install \ mkdocs-material \ mkdocs-autorefs \ mkdocs-material-extensions \ mkdocstrings \ mkdocstrings-python \ mkdocs-awesome-pages-plugin \ mkdocs-open-in-new-tab
-    - run: pip install -e lib/python/
-    - run: mkdocs gh-deploy --force --remote-branch github-pages-documentation
+    - name: Install mkdocs and associated plugins
+      run: pip install \ mkdocs-material \ mkdocs-autorefs \ mkdocs-material-extensions \ mkdocstrings \ mkdocstrings-python \ mkdocs-awesome-pages-plugin \ mkdocs-open-in-new-tab
+    - name: Install Python Adapter Library
+      run: pip install -e lib/python/
+    - name: Generate Java Adapter Library Documentation
+      run: ./lib/java/AdapterLibrary/gradlew -p lib/java/AdapterLibrary dokkaGfm
+    - run: cp -r lib/java/AdapterLibrary/build/dokka/gfm/* docs/references/java-lib/
+    - name: Deploy MKDocs Site
+      run: mkdocs gh-deploy --force --remote-branch github-pages-documentation-test
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Generate Java Adapter Library Documentation
       run: |
         ./lib/java/AdapterLibrary/gradlew -p lib/java/AdapterLibrary dokkaHtml
-        rm -r docs/references/java-lib/*
+        mkdir -p docs/references/java-lib/
         cp -r lib/java/AdapterLibrary/build/dokka/html/* docs/references/java-lib/
     - name: Deploy MKDocs Site
       run: mkdocs gh-deploy --force --remote-branch github-pages-documentation-test

--- a/docs/references/.pages
+++ b/docs/references/.pages
@@ -1,5 +1,6 @@
 nav:
   - Python Adapter Library: python-lib
+  - Java Adapter Library: java-lib
   - ...
   - project_config.md
   - project_connections_config.md

--- a/docs/references/.pages
+++ b/docs/references/.pages
@@ -1,6 +1,6 @@
 nav:
   - Python Adapter Library: python-lib
-  - Java Adapter Library: java-lib
+  - Java Adapter Library: references/java-lib/index.html
   - ...
   - project_config.md
   - project_connections_config.md

--- a/lib/java/AdapterLibrary/build.gradle.kts
+++ b/lib/java/AdapterLibrary/build.gradle.kts
@@ -6,10 +6,11 @@ plugins {
     kotlin("plugin.serialization") version "1.9.0"
     id("org.jetbrains.dokka") version "1.9.0"
     `java-library`
+    `maven-publish`
 }
 
 group = "com.vmware.aria.operations"
-version = "1.0-SNAPSHOT"
+version = "1.0.0-rc.1"
 
 repositories {
     mavenCentral()
@@ -44,4 +45,29 @@ compileKotlin.kotlinOptions {
 val compileTestKotlin: KotlinCompile by tasks
 compileTestKotlin.kotlinOptions {
     jvmTarget = "17"
+}
+
+tasks.register<Jar>("dokkaJavadocJar") {
+    dependsOn(tasks.dokkaJavadoc)
+    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
+    archiveClassifier.set("javadoc")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("library") {
+            from(components["kotlin"])
+        }
+        create<MavenPublication>("allArtifacts") {
+            from(components["kotlin"])
+//            artifact(tasks["sourcesJar"])
+            artifact(tasks["dokkaJavadocJar"])
+        }
+    }
+    repositories {
+//        mavenCentral()
+        maven {
+            url = uri(layout.buildDirectory.dir("publishing-repository"))
+        }
+    }
 }


### PR DESCRIPTION
* Automatically build documentation for Java Adapter Library
* Currently builds to a test branch on pull requests; these will both change once the PR is no longer a draft

Resolves #263 

Menu item:
<img width="556" alt="image" src="https://github.com/vmware/vmware-aria-operations-integration-sdk/assets/3310870/93934660-a289-40dd-9a79-84f735741313">

Documentation from the menu item:
<img width="2044" alt="image" src="https://github.com/vmware/vmware-aria-operations-integration-sdk/assets/3310870/300b345a-4685-4072-a367-3c30d3ae2fdc">
