### PR TITLE
Updates the build.gradle.kts file to support publishing to Maven Central

### DIFF
--- a/lib/java/AdapterLibrary/.gitignore
+++ b/lib/java/AdapterLibrary/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+gradle.properties
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/lib/java/AdapterLibrary/settings.gradle.kts
+++ b/lib/java/AdapterLibrary/settings.gradle.kts
@@ -1,2 +1,2 @@
-rootProject.name = "AdapterLibrary"
+rootProject.name = "IntegrationSDKAdapterLibrary"
 

--- a/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/ObjectTest.java
+++ b/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/ObjectTest.java
@@ -20,11 +20,11 @@ public final class ObjectTest {
         Object object = new Object(simpleKey);
         Object child = new Object(simpleKey2);
         Object parent = new Object(identifierKey);
-        assertFalse(object.getHasUpdatedChildren$AdapterLibrary());
+        assertFalse(object.getHasUpdatedChildren$IntegrationSDKAdapterLibrary());
         object.addParent(parent);
-        assertFalse(object.getHasUpdatedChildren$AdapterLibrary());
+        assertFalse(object.getHasUpdatedChildren$IntegrationSDKAdapterLibrary());
         object.addChild(child);
-        assertTrue(object.getHasUpdatedChildren$AdapterLibrary());
+        assertTrue(object.getHasUpdatedChildren$IntegrationSDKAdapterLibrary());
     }
 
     @Test


### PR DESCRIPTION
* Adds publishing support
* Changes library name for `AdapterLibrary` to `IntegrationSDKAdapterLibrary`
* Adds `gradle.properties` to .gitignore, as it is used for storing sonatype credentials