### PR TITLE
Connections with default suite api credentials now properly set the local values to none

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,8 @@ images/base-python-adapter/target/
 images/base-python-adapter/.ipynb_checkpoints
 
 #IntelliJ project
-.idea
+*.idea
+*.iml
 
 # test/build
 .tox

--- a/vmware_aria_operations_integration_sdk/containerized_adapter_rest_api.py
+++ b/vmware_aria_operations_integration_sdk/containerized_adapter_rest_api.py
@@ -123,7 +123,7 @@ async def get_request_body(port: int, connection: Connection) -> Dict:
             "credentialKey": connection.credential["credential_kind_key"],
             "credentialFields": fields,
         }
-
+    suite_api_connection = connection.get_suite_api_connection()
     request_body: Dict[str, object] = {
         "adapterKey": {
             "name": connection.name,
@@ -132,9 +132,9 @@ async def get_request_body(port: int, connection: Connection) -> Dict:
             "identifiers": identifiers,
         },
         "clusterConnectionInfo": {
-            "userName": connection.suite_api_username,
-            "password": connection.suite_api_password,
-            "hostName": connection.suite_api_hostname,
+            "userName": suite_api_connection.username,
+            "password": suite_api_connection.password,
+            "hostName": suite_api_connection.hostname,
         },
         "certificateConfig": {"certificates": connection.certificates or []},
     }

--- a/vmware_aria_operations_integration_sdk/mp_test.py
+++ b/vmware_aria_operations_integration_sdk/mp_test.py
@@ -75,6 +75,7 @@ from vmware_aria_operations_integration_sdk.project import Connection
 from vmware_aria_operations_integration_sdk.project import get_project
 from vmware_aria_operations_integration_sdk.project import Project
 from vmware_aria_operations_integration_sdk.project import record_project
+from vmware_aria_operations_integration_sdk.project import SuiteApiConnection
 from vmware_aria_operations_integration_sdk.serialization import AdapterDefinitionBundle
 from vmware_aria_operations_integration_sdk.serialization import CollectionBundle
 from vmware_aria_operations_integration_sdk.serialization import ConnectBundle
@@ -107,6 +108,7 @@ from vmware_aria_operations_integration_sdk.validation.input_validators import (
     UniquenessValidator,
 )
 from vmware_aria_operations_integration_sdk.validation.result import Result
+
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -585,7 +587,7 @@ derived from the 'conf/describe.xml' file and are specific to each Management Pa
         "command line arguments or in the interactive prompt.",
     )
     new_connection = Connection(
-        name, identifiers, credentials, None, suite_api_credentials
+        name, identifiers, credentials, None, suite_api_credentials[0], suite_api_credentials[1], suite_api_credentials[2], suite_api_credentials[3]
     )
     project.connections.append(new_connection)
     record_project(project)
@@ -600,7 +602,7 @@ derived from the 'conf/describe.xml' file and are specific to each Management Pa
     return new_connection
 
 
-def get_suite_api_connection_info(project: Project) -> Tuple[str, str, str]:
+def get_suite_api_connection_info(project: Project) -> Tuple[Optional[str], Optional[str], Optional[str], SuiteApiConnection]:
     suiteapi_hostname = get_config_value(
         CONNECTIONS_CONFIG_SUITE_API_HOSTNAME_KEY,
         DEFAULT_PLACEHOLDER_SUITE_API_HOSTNAME,
@@ -667,12 +669,12 @@ def get_suite_api_connection_info(project: Project) -> Tuple[str, str, str]:
                 suiteapi_password,
                 os.path.join(project.path, CONNECTIONS_FILE_NAME),
             )
+            return None, None, None, SuiteApiConnection(suiteapi_hostname, suiteapi_username, suiteapi_password)
+        else:
+            return suiteapi_hostname, suiteapi_username, suiteapi_password, SuiteApiConnection(suiteapi_hostname, suiteapi_username, suiteapi_password)
     else:
-        suiteapi_hostname = None
-        suiteapi_username = None
-        suiteapi_password = None
+        return None, None, None, SuiteApiConnection(suiteapi_hostname, suiteapi_username, suiteapi_password)
 
-    return suiteapi_hostname, suiteapi_username, suiteapi_password
 
 
 def input_parameter(parameter_type: str, parameter: Element, resources: Dict) -> str:

--- a/vmware_aria_operations_integration_sdk/mp_test.py
+++ b/vmware_aria_operations_integration_sdk/mp_test.py
@@ -587,7 +587,14 @@ derived from the 'conf/describe.xml' file and are specific to each Management Pa
         "command line arguments or in the interactive prompt.",
     )
     new_connection = Connection(
-        name, identifiers, credentials, None, suite_api_credentials[0], suite_api_credentials[1], suite_api_credentials[2], suite_api_credentials[3]
+        name,
+        identifiers,
+        credentials,
+        None,
+        suite_api_credentials[0],
+        suite_api_credentials[1],
+        suite_api_credentials[2],
+        suite_api_credentials[3],
     )
     project.connections.append(new_connection)
     record_project(project)
@@ -602,7 +609,9 @@ derived from the 'conf/describe.xml' file and are specific to each Management Pa
     return new_connection
 
 
-def get_suite_api_connection_info(project: Project) -> Tuple[Optional[str], Optional[str], Optional[str], SuiteApiConnection]:
+def get_suite_api_connection_info(
+    project: Project,
+) -> Tuple[Optional[str], Optional[str], Optional[str], SuiteApiConnection]:
     suiteapi_hostname = get_config_value(
         CONNECTIONS_CONFIG_SUITE_API_HOSTNAME_KEY,
         DEFAULT_PLACEHOLDER_SUITE_API_HOSTNAME,
@@ -669,12 +678,30 @@ def get_suite_api_connection_info(project: Project) -> Tuple[Optional[str], Opti
                 suiteapi_password,
                 os.path.join(project.path, CONNECTIONS_FILE_NAME),
             )
-            return None, None, None, SuiteApiConnection(suiteapi_hostname, suiteapi_username, suiteapi_password)
+            return (
+                None,
+                None,
+                None,
+                SuiteApiConnection(
+                    suiteapi_hostname, suiteapi_username, suiteapi_password
+                ),
+            )
         else:
-            return suiteapi_hostname, suiteapi_username, suiteapi_password, SuiteApiConnection(suiteapi_hostname, suiteapi_username, suiteapi_password)
+            return (
+                suiteapi_hostname,
+                suiteapi_username,
+                suiteapi_password,
+                SuiteApiConnection(
+                    suiteapi_hostname, suiteapi_username, suiteapi_password
+                ),
+            )
     else:
-        return None, None, None, SuiteApiConnection(suiteapi_hostname, suiteapi_username, suiteapi_password)
-
+        return (
+            None,
+            None,
+            None,
+            SuiteApiConnection(suiteapi_hostname, suiteapi_username, suiteapi_password),
+        )
 
 
 def input_parameter(parameter_type: str, parameter: Element, resources: Dict) -> str:

--- a/vmware_aria_operations_integration_sdk/vmware_aria_operations_integration_sdk.iml
+++ b/vmware_aria_operations_integration_sdk/vmware_aria_operations_integration_sdk.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/vmware_aria_operations_integration_sdk/vmware_aria_operations_integration_sdk.iml
+++ b/vmware_aria_operations_integration_sdk/vmware_aria_operations_integration_sdk.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
The `connections.json` file has default Suite Api Credentials. The intended behavior is that each connection either:
* Has null values for each of their local values (host, username, password), in which case they use the default values, or
* Has non-null values for each of their local values, in which case those override the defaults.

However, when a connection was loaded into memory, there was only the set of current credentials, so if the connection was ever _resaved_, then values that should have been null would be overwritten with the non-null defaults. This meant that if the defaults ever changed, connections that *should* have been using the defaults would continue to use the old defaults, as those would have been encoded into the individual connection.

In addition, there was a related issue where creating the first new connection and using the default suite api connection would return null values, which when passed to an adapter instance is not valid, and would cause the test to fail with a validation error message.

This PR addresses the above issues.