### PR TITLE
Release Adapter Libraries: Python v1.0.0, Java v1.0.1

### DIFF
--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 VMware Aria Operations Integration SDK Library
 ----------------------------------------------
+## 1.0.0 (10-23-2023)
+* Release version 1.0.0 to coincide with version 1.1.0 of the SDK.
+* Documentation fixes.
+
 ## 0.8.1 (09-15-2023)
 * Improve error handling when log directory is not writable
 

--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vmware-aria-operations-integration-sdk-lib
-version = 0.8.1
+version = 1.0.0
 author = VMware, Inc.
 author_email = krokos@vmware.com
 description = Object model for interacting with the VMware Aria Operations Containerized API

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/new_adapter/build.gradle.kts.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/new_adapter/build.gradle.kts.template
@@ -21,7 +21,7 @@ tasks.named<Jar>("jar") {
 }
 
 dependencies {
-    implementation("com.vmware.aria.operations:integration-sdk-adapter-library:1.0.0")
+    implementation("com.vmware.aria.operations:integration-sdk-adapter-library:1.0.1")
 }
 
 repositories {

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/sample_adapter/build.gradle.kts.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/sample_adapter/build.gradle.kts.template
@@ -21,7 +21,7 @@ tasks.named<Jar>("jar") {
 }
 
 dependencies {
-    implementation("com.vmware.aria.operations:integration-sdk-adapter-library:1.0.0")
+    implementation("com.vmware.aria.operations:integration-sdk-adapter-library:1.0.1")
     implementation("com.github.oshi:oshi-core:6.4.6")
 }
 

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/new_adapter/adapter_requirements.txt
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/new_adapter/adapter_requirements.txt
@@ -1,1 +1,1 @@
-vmware-aria-operations-integration-sdk-lib==0.8.*
+vmware-aria-operations-integration-sdk-lib~=1.0.0

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/sample_adapter/adapter_requirements.txt
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/sample_adapter/adapter_requirements.txt
@@ -1,2 +1,2 @@
-vmware-aria-operations-integration-sdk-lib==0.8.*
+vmware-aria-operations-integration-sdk-lib~=1.0.0
 psutil==5.9.4


### PR DESCRIPTION
* Update Python Library to version 1.0.0
* Update Python templates to use v1.0.x
* Update Java templates to use v1.0.1