### PR TITLE
Match the order that templates and their descriptions appear in mp-init

### DIFF
--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/java_adapter.py
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/java_adapter.py
@@ -67,10 +67,10 @@ class JavaAdapter(AdapterConfig):
                 selection_prompt,
                 "Select a template for your project:",
                 items=self.templates,
-                description="- Sample Adapter: Generates a working adapter with comments "
-                "throughout its code\n"
-                "- New Adapter: The minimum necessary code to start developing "
-                "an adapter\n\n"
+                description="- New Adapter: The minimum necessary code to start developing "
+                "an adapter\n"
+                "- Sample Adapter: Generates a working adapter with comments "
+                "throughout its code\n\n"
                 "For more information visit "
                 "https://vmware.github.io/vmware-aria-operations-integration"
                 "-sdk/get_started/#template-projects",

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/python_adapter.py
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/python_adapter.py
@@ -47,10 +47,10 @@ class PythonAdapter(AdapterConfig):
                 selection_prompt,
                 "Select a template for your project:",
                 items=self.templates,
-                description="- Sample Adapter: Generates a working adapter with comments "
-                "throughout its code\n"
-                "- New Adapter: The minimum necessary code to start developing "
-                "an adapter\n\n"
+                description="- New Adapter: The minimum necessary code to start developing "
+                "an adapter\n"
+                "- Sample Adapter: Generates a working adapter with comments "
+                "throughout its code\n\n"
                 "For more information visit "
                 "https://vmware.github.io/vmware-aria-operations-integration"
                 "-sdk/get_started/#template-projects",


### PR DESCRIPTION
When selecting a template in `mp-init`, the order of the descriptions now matches the order of the templates in the selector.