### PR TITLE
Improve visibility on container repository requirements

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,8 +1,5 @@
 name: documentation
-on:
-  push:
-    branches:
-    - main
+on: [push, pull_request]
 permissions:
   contents: write
 jobs:
@@ -35,6 +32,12 @@ jobs:
         ./lib/java/AdapterLibrary/gradlew -p lib/java/AdapterLibrary dokkaJavadoc
         mkdir -p docs/references/java_project/java_lib/
         cp -r lib/java/AdapterLibrary/build/dokka/javadoc/* docs/references/java_project/java_lib/
+    - name: Build MKDocs Site
+      # If not on the main branch, build the docs to check for errors, but do not deploy
+      if: github.ref != 'refs/heads/main'
+      run: mkdocs build
     - name: Deploy MKDocs Site
+      # If on the main branch, deploy the site
+      if: github.ref == 'refs/heads/main'
       run: mkdocs gh-deploy --force --remote-branch github-pages-documentation
 

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -32,7 +32,7 @@ In addition, at least one Cloud Proxy (also version 8.10 or later) must be set u
     * The repository is public, so that the image can be pulled anonymously (e.g., without first doing a `docker login`)
     * The registry is accessible by your VMware Aria Operations Cloud Proxies
      
-  See the [Container Registry FAQ](/troubleshooting_and_faq/container_registries.md#why-do-i-need-a-container-registry) for additional information.
+  See the [Container Registry FAQ](troubleshooting_and_faq/container_registries.md#why-do-i-need-a-container-registry) for additional information.
 * Python3 3.9.0 or later. Updating to the latest stable version is recommended. Python 3.8 and earlier (including Python2) are not supported. For instructions on installing Python, go
   to [Python's installation documentation](https://wiki.python.org/moin/BeginnersGuide/Download),
   and follow the instructions provided for your operating system.

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -27,7 +27,12 @@ In addition, at least one Cloud Proxy (also version 8.10 or later) must be set u
   go to [Docker's installation documentation](https://docs.docker.com/engine/install/),
   follow the instructions provided for your operating system. Finally, make sure the Docker default socket is enabled in the
   **Advanced** tab in **Settings** (version 4.18.0 and above).
-* Container registry with read and write access (see [Container Registries (FAQs)](./troubleshooting_and_faq/container_registries.md#why-do-i-need-a-container-registry) for additional information).
+* A container registry, set up so that:
+    * You have write access to a repository for pushing an image
+    * The repository is public, so that the image can be pulled anonymously (e.g., without first doing a `docker login`)
+    * The registry is accessible by your VMware Aria Operations Cloud Proxies
+     
+  See the [Container Registry FAQ](/troubleshooting_and_faq/container_registries.md#why-do-i-need-a-container-registry) for additional information.
 * Python3 3.9.0 or later. Updating to the latest stable version is recommended. Python 3.8 and earlier (including Python2) are not supported. For instructions on installing Python, go
   to [Python's installation documentation](https://wiki.python.org/moin/BeginnersGuide/Download),
   and follow the instructions provided for your operating system.

--- a/docs/guides/container_registry_setup.md
+++ b/docs/guides/container_registry_setup.md
@@ -32,7 +32,7 @@ The following are known to work.
     ???+ note
 
         VMware Aria Operations pulls images anonymously, which requires the repository to be public.
-        For more information, see the FAQ: [I can't use a public repository. Are there any options?](troubleshooting_and_faq/container_registries.md#i-cant-use-a-public-repository-are-there-any-options)
+        For more information, see the FAQ: [I can't use a public repository. Are there any options?](../troubleshooting_and_faq/container_registries.md#i-cant-use-a-public-repository-are-there-any-options)
 
 3. Run `mp-build` and set the registry and repository tag when prompted (may look like `harbor.my-organization.com/my-project/adaptername`)
 
@@ -55,7 +55,7 @@ running `mp-build`.
     ???+ note
 
         VMware Aria Operations pulls images anonymously, which requires the repository to be public.
-        For more information, see the FAQ: [I can't use a public repository. Are there any options?](troubleshooting_and_faq/container_registries.md#i-cant-use-a-public-repository-are-there-any-options)
+        For more information, see the FAQ: [I can't use a public repository. Are there any options?](../troubleshooting_and_faq/container_registries.md#i-cant-use-a-public-repository-are-there-any-options)
 
 3. Run `mp-build` and set the registry and repository when prompted (usually looks like `aws_account_id.dkr.ecr.region.amazonaws.com/repository-for-test-mp`)
 
@@ -78,7 +78,7 @@ Docker CLI recommends using a token when using docker hub instead of your login 
     ???+ note
 
         VMware Aria Operations pulls images anonymously, which requires the repository to be public.
-        For more information, see the FAQ: [I can't use a public repository. Are there any options?](troubleshooting_and_faq/container_registries.md#i-cant-use-a-public-repository-are-there-any-options)
+        For more information, see the FAQ: [I can't use a public repository. Are there any options?](../troubleshooting_and_faq/container_registries.md#i-cant-use-a-public-repository-are-there-any-options)
 
 2. Login to docker hub using the CLI docker login
 

--- a/docs/guides/container_registry_setup.md
+++ b/docs/guides/container_registry_setup.md
@@ -6,7 +6,12 @@ For more information about how the Adapter Container Image distribution works, s
 
 The container registry is a key component of this distribution model, and as such it is required when building a Management Pack (i.e., using [`mp-build`](../references/mp-build.md))
 
-There are many options for installing or using a container registry. The following are known to work.
+Any container registry should work if it is set up so that:
+* You have write access to a repository for pushing an image
+* The repository is public, so that the image can be pulled anonymously (e.g., without first doing a `docker login`)
+* The registry is accessible by your VMware Aria Operations Cloud Proxies
+
+The following are known to work.
 
 ## Using the 'Harbor' Container Registry
 
@@ -72,7 +77,7 @@ Docker CLI recommends using a token when using docker hub instead of your login 
  
     ???+ note
 
-        VMware Aria Operations pulls images anonymously, which requires the registry to be public.
+        VMware Aria Operations pulls images anonymously, which requires the repository to be public.
         For more information, see the FAQ: [I can't use a public repository. Are there any options?](troubleshooting_and_faq/container_registries.md#i-cant-use-a-public-repository-are-there-any-options)
 
 2. Login to docker hub using the CLI docker login

--- a/docs/troubleshooting_and_faq/.pages
+++ b/docs/troubleshooting_and_faq/.pages
@@ -1,3 +1,2 @@
 nav:
   - ...
-  - other.md

--- a/docs/troubleshooting_and_faq/container_registries.md
+++ b/docs/troubleshooting_and_faq/container_registries.md
@@ -10,7 +10,15 @@ file. During installation, VMware Aria Operations uses the information inside th
 container from the registry and run the container.
 
 ---
-### How can I setup a container registry for my project
+### What requirements are there for a container registry?
+
+Any container registry should work if it is set up so that:
+* You have write access to a repository for pushing an image
+* The repository is public, so that the image can be pulled anonymously (e.g., without first doing a `docker login`)
+* The registry is accessible by your VMware Aria Operations Cloud Proxies
+
+---
+### How can I setup a container registry for my project?
 
 See [Setting up a Container Registry](../guides/container_registry_setup.md)
 
@@ -39,7 +47,7 @@ there is a workaround. Cloud proxies lookup images locally before attempting to 
 
 1. Build the Management Pack as usual, specifying the private registry.
 2. SSH into the cloud proxy where the adapter is going to run.
-2. Login to docker (usually using `docker login`), and pull the adapter container image used by the management pack. 
+3. Login to docker (usually using `docker login`), and pull the adapter container image used by the management pack. 
    This _must_ have the same image digest SHA that the management pack specifies. 
 
     ???+ note
@@ -47,4 +55,4 @@ there is a workaround. Cloud proxies lookup images locally before attempting to 
         The Digest SHA can be found by unzipping the `.pak` file, then unzipping the `adapter.zip`. The image digest can be found in the 
         file `<ADAPTERNAME>.conf` as the value of the `DIGEST` key.
 
-3. Install Management Pack in VMware Aria operations
+4. Install Management Pack in VMware Aria operations

--- a/docs/troubleshooting_and_faq/installation.md
+++ b/docs/troubleshooting_and_faq/installation.md
@@ -16,6 +16,7 @@ logs:
     By default, the viewer only displays 1000 lines of the file. You may need to 
     increase this. To search, use your browser's search function.
 
+---
 ### Adding an Account: 'Collector is not compatible with adapter type.'
 ![Example of a 'Collector is not compatible with adapter type' error message](../images/not_compatible.png)
 > Example of a 'Collector is not compatible with adapter type' error message
@@ -24,6 +25,7 @@ This message occurs if the `Collector/Group` field in the 'Add Account' page is 
 Integration SDK management packs can only run on a Cloud Proxy. See [below](#how-can-i-install-a-cloud-proxy-in-my-vmware-aria-operations-environment)
 for instructions on installing a Cloud Proxy in VMware Aria Operations.
 
+---
 ### Adding an Account: 'Unknown adapter type'
 
 ![Example of an 'Unknown Adapter Type' error message for an adapter with type/key 'Testserver'](../images/unknown_adapter_type.png)
@@ -35,6 +37,30 @@ This message can occur for several reasons:
 - Check that the Cloud Proxy version supports containerized adapters. Containerized adapter
   support was added in VMware Aria Operations version 8.10.0.
 
+---
+### Adding an Account: "Wait for response of task 'Test connection' is timed out for collector '<cloud_proxy>'"
+
+If the test connection times out, logs can be found in `collector.log`. In particular, if you see a message similar to this:
+```
+Status 404: {"message":"manifest for <image> not found: manifest unknown: The named manifest is not known to the registry."}
+```
+It means that the Docker Repository is not public. See 
+[Setting up a Container Registry](container_registries.md#how-can-i-setup-a-container-registry-for-my-project) and if necessary,
+a [workaround (for development only) for using a public repository](container_registries.md#i-cant-use-a-public-repository-are-there-any-options).
+
+Access the collector log using the Aria Operations Cloud Proxy the adapter is running on. 
+There are two methods to access these logs:
+* Using `ssh`: `ssh` into the cloud proxy the adapter is running on and navigate to 
+  `$ALIVE_BASE/user/log`. Test Connection issues are logged to the collector log 
+  `collector.log`. Generally, a good place to start is to search that log file
+  for recent `ERROR` level logs.
+* Using the VMware Aria Operations UI: Navigate to `Administration` &rarr;
+  `Support Logs`. Expand the first `Cloud Proxy` item that the adapter is running on, 
+  expand `COLLECTOR`, and select the `collector.log` file. By default, the viewer only 
+  displays 1000 lines of the file. You may need to increase this. To search, use your 
+  browser's search function.
+
+---
 ### How can I install a Cloud Proxy in my VMware Aria Operations environment?
 
 For instructions for setting up a Cloud Proxy, see


### PR DESCRIPTION
In particular, improve visibility on the requirement that repositories are public.

Add additional troubleshooting section that includes the case that the adapter fails because the repository is not public.

Also, improved the documentation automation, as the site was failing to build but there was no indication of that until the PR was merged and the site attempted to deploy from the `main` branch. This way the site should attempt to build on each PR, but will still only deploy once it is merged into `main`.
