### PR TITLE
Correctly handle the 'is_password' attribute in credential fields

### DIFF
--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterInstance.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterInstance.kt
@@ -17,7 +17,11 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable
-data class CredentialField(val key: String, val value: String)
+data class CredentialField(
+    val key: String,
+    val value: String,
+    @SerialName("is_password") val isPassword: Boolean,
+)
 
 @Serializable
 class Credential(

--- a/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/AdapterInstanceTest.java
+++ b/lib/java/AdapterLibrary/src/test/java/com/vmware/aria/operations/AdapterInstanceTest.java
@@ -60,11 +60,13 @@ class AdapterInstanceTest {
             "credential_fields", arr(List.of(
                     obj(Map.of(
                             "key", str(FIELD1),
-                            "value", str(FIELD1_VALUE)
+                            "value", str(FIELD1_VALUE),
+                            "is_password", bool(false)
                     )),
                     obj(Map.of(
                             "key", str(FIELD2),
-                            "value", str(FIELD2_VALUE)
+                            "value", str(FIELD2_VALUE),
+                            "is_password", bool(false)
                     ))
             ))
     ));


### PR DESCRIPTION
Fixes an issue where deserializing a credential field with the `is_password` attribute would error, because there was no matching attribute in the `CredentialField` class.