### PR TITLE
Fix typo in logs directory

### DIFF
--- a/docs/troubleshooting_and_faq/logs.md
+++ b/docs/troubleshooting_and_faq/logs.md
@@ -10,7 +10,7 @@ project.
 ###  Where are the adapter logs stored in VMware Aria Operations?
 
 Logs are generated and stored on the cloud proxy where the adapter is running at 
-`$ALIVE_BASE/user/log/adapter/<ADAPTERKEY>/<ADAPTER_INTERNAL_INSTANCE_ID>`.
+`$ALIVE_BASE/user/log/adapters/<ADAPTERKEY>/<ADAPTER_INTERNAL_INSTANCE_ID>`.
 
 `ADAPTERKEY` should match the adapter key used in the `manifest.txt`, and the `ADAPTER_INTERNAL_INSTANCE_ID` should
 match the Internal ID


### PR DESCRIPTION
There's a reference later on this page that is correct, but this reference to the directory is incorrect.