### PR TITLE
Create 'images' directory structure in correct project location

### DIFF
--- a/docs/references/java_project/index.md
+++ b/docs/references/java_project/index.md
@@ -30,7 +30,11 @@ files and directories specific to Java (highlighted below):
 ├── manifest.txt
 ├── requirements.txt
 ├── conf
-│   └── describeSchema.xsd
+│   ├── describeSchema.xsd
+│   └──  images
+│       ├── AdapterKind
+│       ├── ResourceKind
+│       └── TraversalSpec
 ├── content
 │   ├── alertdefs
 │   │   └── alertDefinitionSchema.xsd
@@ -49,10 +53,6 @@ files and directories specific to Java (highlighted below):
 │   ├── symptomdefs
 │   └── traversalspecs
 │       └── traversalSpecsSchema.xsd
-├── images
-│   ├── AdapterKind
-│   ├── ResourceKind
-│   └── TraversalSpec
 ├── resources
 │   └── resources.properties
 └── src

--- a/docs/references/mp-init.md
+++ b/docs/references/mp-init.md
@@ -98,7 +98,10 @@ The init script creates a project in the given path with the following structure
 ├── venv-ADAPTER NAME
 ├── conf
 │   ├── describeSchema.xsd
-│   └── resources
+│   └──  images
+│       ├── AdapterKind
+│       ├── ResourceKind
+│       └── TraversalSpec
 ├── content
 │   ├── alertdefs
 │   │   └── alertDefinitionSchema.xsd

--- a/docs/references/python_project/index.md
+++ b/docs/references/python_project/index.md
@@ -34,7 +34,11 @@ files and directories specific to Python (highlighted below):
 │   ├── adapter.py
 │   └── constants.py
 ├── conf
-│   └── describeSchema.xsd
+│   ├── describeSchema.xsd
+│   └──  images
+│       ├── AdapterKind
+│       ├── ResourceKind
+│       └── TraversalSpec
 ├── content
 │   ├── alertdefs
 │   │   └── alertDefinitionSchema.xsd
@@ -53,10 +57,6 @@ files and directories specific to Python (highlighted below):
 │   ├── symptomdefs
 │   └── traversalspecs
 │       └── traversalSpecsSchema.xsd
-├── images
-│   ├── AdapterKind
-│   ├── ResourceKind
-│   └── TraversalSpec
 └── resources
     └── resources.properties
 ```

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_config.py
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_config.py
@@ -70,7 +70,7 @@ class AdapterConfig(ABC):
 
         self.conf_dir_path = os.path.join(project_path, "conf")
         self.conf_resources_dir_path = os.path.join(project_path, "resources")
-        self.conf_images_dir_path = os.path.join(project_path, "images")
+        self.conf_images_dir_path = os.path.join(self.conf_dir_path, "images")
 
         self.response_values: Dict[str, Any] = {
             "display_name": display_name,


### PR DESCRIPTION
The 'images' directory structure was incorrectly created as a top-level directory, however to work correctly it needs to be a subdirectory of the 'conf' directory.

Resolves #369 