### PR TITLE
Bump Java Library version to 1.0.4

### DIFF
--- a/lib/java/AdapterLibrary/build.gradle.kts
+++ b/lib/java/AdapterLibrary/build.gradle.kts
@@ -5,14 +5,14 @@ plugins {
     kotlin("jvm") version "1.9.0"
     kotlin("plugin.serialization") version "1.9.0"
     id("org.jetbrains.dokka") version "1.9.0"
-    id("io.github.gradle-nexus.publish-plugin") version "2.0.0-rc-1"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0-rc-2"
     `java-library`
     `signing`
     `maven-publish`
 }
 
 group = "com.vmware.aria.operations"
-version = "1.0.3"
+version = "1.0.4"
 
 java {
     toolchain {

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterInstance.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterInstance.kt
@@ -64,11 +64,12 @@ class Certificates(private val certificates: List<CertificateInfo>) :
 @Serializable
 data class CollectionWindow(
     /**
-     * The start of the window. On the first collection, this will be set to `0`.
+     * The start of the window in milliseconds since the Epoch. On the first collection,
+     * this will be set to `0`.
      */
     @SerialName("start_time") val startTime: Double,
     /**
-     * The end of the window
+     * The end of the window in milliseconds since the Epoch.
      */
     @SerialName("end_time") val endTime: Double,
 )

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/new_adapter/build.gradle.kts.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/new_adapter/build.gradle.kts.template
@@ -21,7 +21,7 @@ tasks.named<Jar>("jar") {
 }
 
 dependencies {
-    implementation("com.vmware.aria.operations:integration-sdk-adapter-library:1.0.1")
+    implementation("com.vmware.aria.operations:integration-sdk-adapter-library:1.0.4")
 }
 
 repositories {

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/sample_adapter/build.gradle.kts.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/sample_adapter/build.gradle.kts.template
@@ -21,7 +21,7 @@ tasks.named<Jar>("jar") {
 }
 
 dependencies {
-    implementation("com.vmware.aria.operations:integration-sdk-adapter-library:1.0.1")
+    implementation("com.vmware.aria.operations:integration-sdk-adapter-library:1.0.4")
     implementation("com.github.oshi:oshi-core:6.4.6")
 }
 


### PR DESCRIPTION
Bump Java Library version to 1.0.4

Improve documentation around collection windows

Set new Java Projects to use the latest released version of the Java Library.

Resolves #355 