### PR TITLE
Explicitly exit at end of execution

### DIFF
--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/new_adapter/src/main/java/Adapter.java.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/new_adapter/src/main/java/Adapter.java.template
@@ -196,6 +196,7 @@ public class Adapter {
             }
         } finally {
             logger.info(Timing.graph());
+            System.exit(0);
         }
     }
 }

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/sample_adapter/src/main/java/Adapter.java.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/java/sample_adapter/src/main/java/Adapter.java.template
@@ -317,6 +317,7 @@ public class Adapter {
             }
         } finally {
             logger.info(Timing.graph());
+            System.exit(0)
         }
     }
 }

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/new_adapter/app/adapter.py.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/new_adapter/app/adapter.py.template
@@ -143,7 +143,7 @@ def main(argv: List[str]) -> None:
         # `inputfile` and `outputfile` are always automatically appended to the
         # argument list by the server
         logger.error("Arguments must be <method> <inputfile> <ouputfile>")
-        exit(1)
+        sys.exit(1)
 
     method = argv[0]
     try:
@@ -161,13 +161,13 @@ def main(argv: List[str]) -> None:
                 logger.info(
                     "get_adapter_definition method did not return an AdapterDefinition"
                 )
-                exit(1)
+                sys.exit(1)
         else:
             logger.error(f"Command {method} not found")
-            exit(1)
+            sys.exit(1)
     finally:
         logger.info(Timer.graph())
-        exit(0)
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/new_adapter/app/adapter.py.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/new_adapter/app/adapter.py.template
@@ -167,6 +167,7 @@ def main(argv: List[str]) -> None:
             exit(1)
     finally:
         logger.info(Timer.graph())
+        exit(0)
 
 
 if __name__ == "__main__":

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/sample_adapter/app/adapter.py.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/sample_adapter/app/adapter.py.template
@@ -233,7 +233,7 @@ def main(argv: List[str]) -> None:
         # `inputfile` and `outputfile` are always automatically appended to the
         # argument list by the server
         logger.error("Arguments must be <method> <inputfile> <ouputfile>")
-        exit(1)
+        sys.exit(1)
 
     method = argv[0]
     try:
@@ -251,13 +251,13 @@ def main(argv: List[str]) -> None:
                 logger.info(
                     "get_adapter_definition method did not return an AdapterDefinition"
                 )
-                exit(1)
+                sys.exit(1)
         else:
             logger.error(f"Command {method} not found")
-            exit(1)
+            sys.exit(1)
     finally:
         logger.info(Timer.graph())
-        exit(0)
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/sample_adapter/app/adapter.py.template
+++ b/vmware_aria_operations_integration_sdk/adapter_configurations/adapter_templates/python/sample_adapter/app/adapter.py.template
@@ -257,6 +257,7 @@ def main(argv: List[str]) -> None:
             exit(1)
     finally:
         logger.info(Timer.graph())
+        exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #359 

Notes from investigation:
* OkHttp has the hanging issue, but the exact same code (as close as Ktor allows, which is quite close) using the Cio engine does not.
* In both cases, the server gets the result back in approximately the same amount of time. The hanging occurs after all other execution is finished.
* In the OkHttp case, the culprit appears to be an "OkHttp Dispatcher" thread that is still running. I've found a good number of issues related to this, but all from around ~2020 and claim be resolved in the versions we are using (e.g., https://youtrack.jetbrains.com/issue/KTOR-396)
* I tried manually closing the client, engine, dispatcher, executor, connection pool, etc - with no success. As near as I can tell, closing just the client should be sufficient, but clearly isn't in our case
* If I run the exact same code outside of a container, I don't have this problem. I don't know what is different about the container environment. It's also possible (maybe?) that there is a thread sticking around longer but it's not noticeable because the system itself isn't waiting on it to close. But I'm not sure how to test that, and it seems unlikely.
* If we explicitly call 'System.exit(0)' at the end of collection, everything works as expected. I don't love it, but this is likely the best (and most general) solution. The user shouldn't be doing anything at this point - any cleanup should have already happened, all results have already been sent back to the server, and the user would expect that the program exits here immediately anyway.
* I don't know if the issue can present itself in Python in the same way, but I have added exits at the same place in the Python templates for consistency