### PR TITLE
Handle all exceptions when validating images

### DIFF
--- a/vmware_aria_operations_integration_sdk/validation/input_validators.py
+++ b/vmware_aria_operations_integration_sdk/validation/input_validators.py
@@ -163,9 +163,11 @@ class ImageValidator(Validator):  # type: ignore
             raise ValidationError(
                 message="Image must be in PNG format and 256x256 pixels."
             )
-        except UnidentifiedImageError as e:
+        except Exception as e:
             raise ValidationError(
-                message=f"{e}. Image must be in PNG format and 256x256 pixels."
+                message=f"{e}. Image must be in PNG format and 256x256 pixels.".replace(
+                    "..", "."
+                )
             )
 
 


### PR DESCRIPTION
The specific error in the ticket seemed to be resolved already, but I was able to find other cases where an exception was thrown that wasn't being caught. I changed the code to catch any exception to address this.

Resolves #131 