### PR TITLE
Improve Certificate Handling

### DIFF
--- a/lib/java/AdapterLibrary/CHANGELOG.md
+++ b/lib/java/AdapterLibrary/CHANGELOG.md
@@ -1,5 +1,8 @@
 VMware Aria Operations Integration SDK Adapter Library for Java
 ---------------------------------------------------------------
+## Unreleased
+* Add method for retrieving the x509 certificate from the CertificateInfo class
+
 ## 1.0.3 (03-12-2024)
 * Fix deserialization error when reading in certificate data.
 

--- a/lib/java/AdapterLibrary/build.gradle.kts
+++ b/lib/java/AdapterLibrary/build.gradle.kts
@@ -80,12 +80,7 @@ publishing {
                     developer {
                         id.set("kjrokos")
                         name.set("Kyle Rokos")
-                        email.set("krokos@vmware.com")
-                    }
-                    developer {
-                        id.set("quirogas")
-                        name.set("Santiago Quiroga Cubillos")
-                        email.set("squirogacubi@vmware.com")
+                        email.set("kyle.rokos@broadcom.com")
                     }
                 }
                 scm {

--- a/lib/java/AdapterLibrary/build.gradle.kts
+++ b/lib/java/AdapterLibrary/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.vmware.aria.operations"
-version = "1.0.4"
+version = "1.1.0"
 
 java {
     toolchain {

--- a/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterInstance.kt
+++ b/lib/java/AdapterLibrary/src/main/kotlin/com/vmware/aria/operations/AdapterInstance.kt
@@ -15,6 +15,10 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import java.io.ByteArrayInputStream
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Base64;
 
 @Serializable
 data class CredentialField(
@@ -41,8 +45,14 @@ class CertificateInfo(
     @SerialName("cert_pem_string") val certPem: String,
     @SerialName("is_invalid_hostname_accepted") val isInvalidHostnameAccepted: Boolean,
     @SerialName("is_expired_certificate_accepted") val isExpiredCertAccepted: Boolean,
-
-)
+) {
+    fun certificate(): X509Certificate {
+        val certBytes = Base64.getDecoder().decode(certPem)
+        return CertificateFactory.getInstance("X.509").generateCertificate(
+            ByteArrayInputStream(certBytes)
+        ) as X509Certificate
+    }
+}
 
 /**
  * Class that represents a list of validated SSL certificates that have been verified

--- a/lib/python/CHANGELOG.md
+++ b/lib/python/CHANGELOG.md
@@ -1,5 +1,8 @@
 VMware Aria Operations Integration SDK Library
 ----------------------------------------------
+## Unreleased
+* Add a CertificateInfo class to avoid having to interact with json (dict) objects
+
 ## 1.0.0 (10-23-2023)
 * Release version 1.0.0 to coincide with version 1.1.0 of the SDK.
 * Documentation fixes.

--- a/lib/python/setup.cfg
+++ b/lib/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vmware-aria-operations-integration-sdk-lib
-version = 1.0.1
+version = 1.1.0
 author = VMware, Inc.
 author_email = krokos@vmware.com
 description = Object model for interacting with the VMware Aria Operations Containerized API
@@ -24,6 +24,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     aenum == 3.1.11
+    cryptography == 44.0.0
 
 [options.package_data]
 * = py.typed

--- a/lib/python/src/aria/ops/adapter_instance.py
+++ b/lib/python/src/aria/ops/adapter_instance.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import sys
-from typing import Any
 from typing import Dict
 from typing import Optional
 
+from aria.ops.certificate_info import CertificateInfo
 from aria.ops.object import Identifier
 from aria.ops.object import Key
 from aria.ops.object import Object
@@ -58,10 +58,12 @@ class AdapterInstance(Object):  # type: ignore
             self.suite_api_client = None
 
         certificate_config = json.get("certificate_config")
+        self.certificates: list[CertificateInfo] = []
         if type(certificate_config) is dict:
-            self.certificates: list = certificate_config.get("certificates", [])
-        else:
-            self.certificates = []
+            self.certificates = [
+                CertificateInfo(cert)
+                for cert in certificate_config.get("certificates", [])
+            ]
 
         self.collection_number: Optional[int] = json.get("collection_number", None)
         self.collection_window: Optional[Dict] = json.get("collection_window", None)
@@ -77,7 +79,7 @@ class AdapterInstance(Object):  # type: ignore
         """
         return self.suite_api_client
 
-    def get_certificates(self) -> list[Any]:
+    def get_certificates(self) -> list[CertificateInfo]:
         """
         Gets a list of all certificates that have been validated by a CA or manually
         accepted by a user.

--- a/lib/python/src/aria/ops/certificate_info.py
+++ b/lib/python/src/aria/ops/certificate_info.py
@@ -1,0 +1,41 @@
+#  © 2025 Broadcom. All Rights Reserved.
+#  The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+#  SPDX-License-Identifier: Apache-2.0
+from cryptography import x509
+
+
+class CertificateInfo(object):
+    """Class representing an x509 certificate for verifying an SSL connection."""
+
+    def __init__(self, certificate: dict) -> None:
+        self.certificate = certificate
+
+    def get_certificate_string(self) -> str:
+        """
+        Gets a string representation of the certificate.
+        Returns:
+            str: String representation of the certificate.
+        """
+        return str(self.certificate.get("cert_pem_string"))
+
+    def get_certificate_object(self) -> x509.Certificate:
+        """
+        Gets the certificate as an x509.Certificate object.
+        Returns:
+            x509.Certificate: the certificate.
+        """
+        return x509.load_pem_x509_certificate(self.get_certificate_string().encode())
+
+    def is_expired_certificate_accepted(self) -> bool:
+        """
+        Returns:
+            bool: True if the certificate can be used if it is expired.
+        """
+        return bool(self.certificate.get("is_expired_certificate_accepted"))
+
+    def is_invalid_hostname_accepted(self) -> bool:
+        """
+        Returns:
+            bool: True if the certificate can be used if the hostnames do not match.
+        """
+        return bool(self.certificate.get("is_invalid_hostname_accepted"))


### PR DESCRIPTION
* Add 'CertificateInfo' class to Python Adapter Library to match how the Java Adapter Library handles certificates.
* In Python and Java Adapter Libraries, add method for getting the x509 certificate that the CertificateInfo's pem string encodes

Resolves #356 