### PR TITLE
Documentation/fix broken links

### DIFF
--- a/docs/references/architecture.md
+++ b/docs/references/architecture.md
@@ -25,7 +25,7 @@ A management pack consists of content, metadata, and an adapter.
 > 
 > A Cloud Proxy collector process managing adapter containers, which each correspond to
 > one adapter instance. Within each container is the REST server and the adapter 
-> process. The [Commands.cfg](#commandscfg) file tells the REST server how to run the
+> process. The [Commands.cfg](#calling-the-adaptercollection-code-from-the-rest-server) file tells the REST server how to run the
 > adapter process for each endpoint.
  
 ### Adapter/Collection Code

--- a/docs/references/connections.md
+++ b/docs/references/connections.md
@@ -38,7 +38,7 @@ and the username and password can be any user with permission to access the Suit
 default. If you select 'yes', then every connection in this project will use the 
 provided credentials, unless they explicitly override them. To learn more about how 
 Suite API connections are handled, see the 
-[project connections file](project_connections_config.md#suiteapihostname-string) documentation.
+[project connections file](project_connections_config.md#suite_api_hostname-string) documentation.
 
 ### How are Connections Stored?
 

--- a/docs/references/global_config.md
+++ b/docs/references/global_config.md
@@ -5,7 +5,7 @@
 
 Specifies the default container registry path
 to be used by [mp-build](mp-build.md) any time
-the [project config file](project_config.md#containerrepository-string) doesn't contain a [container_repository](./project_config.md#containerrepository-string).
+the [project config file](project_config.md) doesn't contain a [container_repository](./project_config.md#container_repository-string).
 This key value should contain the path
 used to [tag](https://docs.docker.com/engine/reference/commandline/tag/) and push images to a new repository.
 

--- a/docs/references/mp-build.md
+++ b/docs/references/mp-build.md
@@ -7,7 +7,7 @@ The mp-build tool builds a pak file and uploads the adapter container to a regis
 any tests on the adapter; to test the adapter code, use the [test tool](mp-test.md).
 
 ## Prerequisites
-* The [VMware Cloud Foundation Operations Integration SDK](../index.md#installation) is installed, with the virtual environment active.
+* The [VMware Cloud Foundation Operations Integration SDK](../get_started.md#installation) is installed, with the virtual environment active.
 * A Management Pack project created by the [mp-init](mp-init.md) tool.
 * Write permissions to a container registry that is accessible from VCF Operations.
 * Access to the Docker daemon
@@ -15,7 +15,7 @@ any tests on the adapter; to test the adapter code, use the [test tool](mp-test.
 ???+ info
 
     When the Docker daemon is not accessible, mp-init might crash with the "Cannot connect to the Docker daemon"
-    error. For more information about this error, visit the [Docker](../troubleshooting_and_faq/docker.md#when-using-mp-test-and-mp-build-i-get-a-cannot-connect-to-the-docker-daemon-error)
+    error. For more information about this error, visit the [Docker](../troubleshooting_and_faq/docker.md#when-using-mp-test-and-mp-build-i-get-a-cannot-connect-to-the-docker-daemon-message)
     Troubleshooting and FAQs section.
 
 ## Input

--- a/docs/references/mp-test.md
+++ b/docs/references/mp-test.md
@@ -9,14 +9,14 @@ If the test tool runs error-free on each endpoint, then the Management Pack shou
 
 ## Prerequisites
 
-* The [VCF Operations Integration SDK](../index.md#installation) is installed, with the virtual environment active.
+* The [VCF Operations Integration SDK](../get_started.md#installation) is installed, with the virtual environment active.
 * A Management Pack project created by the [mp-init](mp-init.md) tool.
 * Access to the Docker daemon
 
 ???+ info
 
     When the Docker daemon is not accessible, mp-init might crash with the "Cannot connect to the Docker daemon"
-    error. For more information about this error, visit the [Docker](../troubleshooting_and_faq/docker.md#when-using-mp-test-and-mp-build-i-get-a-cannot-connect-to-the-docker-daemon-error)
+    error. For more information about this error, visit the [Docker](../troubleshooting_and_faq/docker.md#when-using-mp-test-and-mp-build-i-get-a-cannot-connect-to-the-docker-daemon-message)
     Troubleshooting and FAQs section.
 
 ## Input

--- a/docs/references/project_config.md
+++ b/docs/references/project_config.md
@@ -18,7 +18,7 @@ This key value should contain the  `host` and `path` used to
 [tag](https://docs.docker.com/engine/reference/commandline/tag/) and push images to
 the specified repository.
 
-This overrides the [default_container_registry_path](global_config.md#defaultcontainerregistrypath-string-optional)
+This overrides the [default_container_registry_path](global_config.md#default_container_registry_path-string-optional)
 if it is present.
 
 ??? example

--- a/docs/references/project_connections_config.md
+++ b/docs/references/project_connections_config.md
@@ -134,7 +134,7 @@ The name of the connection. This is used as the connection identifier and can be
     ...
     name:"host-1"
     },
-    {
+    {[container_registries.md](../troubleshooting_and_faq/container_registries.md)
     ...
     name:"host-2"
     }

--- a/docs/troubleshooting_and_faq/installation.md
+++ b/docs/troubleshooting_and_faq/installation.md
@@ -23,7 +23,7 @@ to access these logs:
 > Example of a 'Collector is not compatible with adapter type' error message
 
 This message occurs if the `Collector/Group` field in the 'Add Account' page is set to a collector that is not a Cloud Proxy.
-Integration SDK management packs can only run on a Cloud Proxy. See [below](#how-can-i-install-a-cloud-proxy-in-my-vmware-aria-operations-environment)
+Integration SDK management packs can only run on a Cloud Proxy. See [below](#how-can-i-install-a-cloud-proxy-in-my-vcf-operations-environment)
 for instructions on installing a Cloud Proxy in VCF Operations.
 
 ---
@@ -33,7 +33,7 @@ for instructions on installing a Cloud Proxy in VCF Operations.
 > Example of an 'Unknown Adapter Type' error message for an adapter with type/key 'Testserver'.
 
 This message can occur for several reasons:
-- The Collector/Group the MP is running on is a Cloud Proxy. See [below](#how-can-i-install-a-cloud-proxy-in-my-vmware-aria-operations-environment)
+- The Collector/Group the MP is running on is a Cloud Proxy. See [below](#how-can-i-install-a-cloud-proxy-in-my-vcf-operations-environment)
   for instructions on installing a Cloud Proxy in VCF Operations.
 - Check that the Cloud Proxy version supports containerized adapters. Containerized adapter
   support was added in VCF Operations version 8.10.0.

--- a/lib/python/src/aria/ops/definition/object_type.py
+++ b/lib/python/src/aria/ops/definition/object_type.py
@@ -46,7 +46,7 @@ class ObjectType(GroupType):  # type: ignore
 
         Args:
             key (str): Used to identify the parameter.
-            label (Optinal[str]): Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
+            label (Optional[str]): Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
             required (bool): True if this parameter is required. Defaults to True.
             is_part_of_uniqueness (bool): True if the parameter should be used for object identification. Defaults to True.
             default (Optional[str]): The default value of the parameter.
@@ -82,7 +82,7 @@ class ObjectType(GroupType):  # type: ignore
             label (Optional[str]): Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
             required (bool): True if this parameter is required. Defaults to True.
             is_part_of_uniqueness (bool): True if the parameter should be used for object identification. Defaults to True.
-            default ([Optional[int]): The default value of the parameter.
+            default (Optional[int]): The default value of the parameter.
 
         Returns:
              The created Int Identifier.
@@ -114,9 +114,8 @@ class ObjectType(GroupType):  # type: ignore
 
         Args:
             key (str): Used to identify the parameter.
-            values (list[Union[str, tuple[str, str]]]): An array containing all enum values. If 'default' is specified and not part of this array, it
-            will be added as an additional enum value (values are case-sensitive). Enum values are not localizable.
-            label [Optinal[str]): Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
+            values (list[Union[str, tuple[str, str]]]): An array containing all enum values. If 'default' is specified and not part of this array, it will be added as an additional enum value. Notes: Enum values are case-sensitive. Enum values are not localizable.
+            label (Optional[str]): Label that is displayed in the VMware Aria Operations UI. Defaults to the key.
             required (bool): True if this parameter is required. Defaults to True.
             is_part_of_uniqueness (bool): True if the parameter should be used for object identification. Defaults to True.
             default (Optional[str]): The default value of the parameter.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: VMware Aria Operations Integration SDK
+site_name: VMware Cloud Foundation Operations Integration SDK
 repo_url: https://github.com/vmware/vmware-aria-operations-integration-sdk
 site_url: https://vmware.github.io/vmware-aria-operations-integration-sdk/sdk/
 docs_dir: docs


### PR DESCRIPTION
When deploying the 1.2 documentation, I noticed there were a number of broken links that were being reported as 'info' or 'warning' level. This didn't stop the documentation task from succeeding, but should be fixed. The documentation site is already updated with these changes. 