### PR TITLE
Explicitly state that Python 3.13 is not yet supported in the documentation

### DIFF
--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -34,7 +34,7 @@ In addition, at least one Cloud Proxy (also version 8.10 or later) must be set u
      
     See the [Container Registry FAQ](troubleshooting_and_faq/container_registries.md#why-do-i-need-a-container-registry) for additional information.
   
-* Python3 3.9.0 or later. Updating to the latest stable version is recommended. Python 3.8 and earlier (including Python2) are not supported. For instructions on installing Python, go
+* Python3 3.9.0 to 3.12. Updating to the latest stable 3.12 release is recommended. Python 3.13 is not supported yet, and Python 3.8 and earlier (including Python2) are not supported. For instructions on installing Python, go
   to [Python's installation documentation](https://wiki.python.org/moin/BeginnersGuide/Download),
   and follow the instructions provided for your operating system.
 * Pipx (recommended) or pip. If Python3 is installed, pip is most likely also installed.


### PR DESCRIPTION
Resolves #411 